### PR TITLE
fix: Add Tilt configs for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Dockerfile.cross
 /charts
 /cdk8s
 /git
+
+local.tiltfile

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ Dockerfile.cross
 /cdk8s
 /git
 
-local.tiltfile
+tilt-settings.json

--- a/README.md
+++ b/README.md
@@ -2,9 +2,51 @@
 
 ## Development
 
-- `make install run` - runs the operator outside of the cluster. This is in a
-  non production mode, so the console will fail to load operator logs because
-  its not inside the cluster
+### Prerequisites
+
+- A Kubernetes cluster (e.g. [kind](https://kind.sigs.k8s.io/))
+- [Tilt](https://tilt.dev/)  
+
+#### Install Kind
+
+A kubernetes cluster is required to run the operator. [kind](https://kind.sigs.k8s.io/) is recommended for local development. Install `kind` and
+create a cluster:
+
+```bash
+brew install kind
+kind create cluster
+```
+
+This will create a new kind cluster with the name `kind`.  The kubernetes context will be called `kind-kind`.
+
+#### Install Tilt
+
+[Tilt](https://tilt.dev/) is a tool for local development of Kubernetes applications. Install `tilt`:
+
+```bash
+brew install tilt
+```
+
+### Configuring and Running Tilt
+
+#### Tilt Settings
+There are settings for Tilt that can be configured using a `tilt-settings.json` file.  The settings file is not checked
+into source control.  A sample settings file is provided in `tilt-settings.sample.json`.  To use the sample settings file,
+copy it to `tilt-settings.json`
+
+By default, Tilt is configured to only allow connections to the following Kubernetes contexts:
+
+- `docker-desktop`
+- `kind-kind`
+- `minikube`
+
+Please add any additional contexts to the `allowedContexts` list in your `tilt-settings.json` file.
+
+#### Running Tilt
+```bash
+tilt up
+```
+
 
 ## Testing
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -64,6 +64,8 @@ DIRNAME = os.path.basename(os. getcwd())
 
 local(manifests() + generate())
 
+local_resource('Minio', 'kubectl apply -f ./hack/testing-manifests/minio/minio.yaml')
+
 local_resource('CRD', manifests() + 'kustomize build config/crd | kubectl apply -f -', deps=["api"])
 
 local_resource('RBAC', 'kustomize build config/rbac | kubectl apply -f -', deps=["config/rbac"])
@@ -75,7 +77,7 @@ deps.append('api')
 
 local_resource('Watch&Compile', generate() + binary(), deps=deps, ignore=['*/*/zz_generated.deepcopy.go'])
 
-local_resource('Sample YAML', 'kustomize build ./config/samples | kubectl apply -f -', deps=["./config/samples"], resource_deps=["controller-manager"])
+local_resource('Sample YAML', 'kubectl apply -f ./hack/testing-manifests/wandb/default.yaml', deps=["./hack/testing-manifests/wandb/default.yaml"], resource_deps=["controller-manager"])
 
 docker_build_with_restart(IMG, '.',
  dockerfile_contents=DOCKERFILE,

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,87 @@
+allowed_k8s_contexts = []
+
+# Remember to add `local.tiltfile` to .gitignore
+if os.path.exists('local.tiltfile'):
+  load_dynamic('local.tiltfile')
+
+allow_k8s_contexts(allowed_k8s_contexts)
+
+os.putenv('PATH', './bin:' + os.getenv('PATH'))
+
+load('ext://restart_process', 'docker_build_with_restart')
+
+DOCKERFILE = '''
+FROM registry.access.redhat.com/ubi9/ubi
+
+ADD tilt_bin/manager /manager
+
+ENV HELM_CACHE_HOME=/helm/.cache/helm
+ENV HELM_CONFIG_HOME=/helm/.config/helm
+ENV HELM_DATA_HOME=/helm/.local/share/helm
+'''
+DOMAIN = "wandb.com"
+GROUP = "apps"
+VERSION = "v1"
+KIND = "wandb"
+IMG = 'controller:latest'
+CONTROLLERGEN = 'rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases;'
+DISABLE_SECURITY_CONTEXT = True
+
+def yaml():
+    data = local('cd config/manager; kustomize edit set image controller=' + IMG + '; cd ../..; kustomize build config/manager')
+    if DISABLE_SECURITY_CONTEXT:
+        decoded = decode_yaml_stream(data)
+        if decoded:
+            for d in decoded:
+                # Live update conflicts with SecurityContext, until a better solution, just remove it
+                if d["kind"] == "Deployment":
+                    if "securityContext" in d['spec']['template']['spec']:
+                        d['spec']['template']['spec'].pop('securityContext')
+                    for c in d['spec']['template']['spec']['containers']:
+                        if "securityContext" in c:
+                            c.pop('securityContext')
+
+        return encode_yaml_stream(decoded)
+    return data
+
+def manifests():
+    return 'controller-gen ' + CONTROLLERGEN
+
+def generate():
+    return 'controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./...";'
+
+def vetfmt():
+    return 'go vet ./...; go fmt ./...'
+
+# build to tilt_bin beause kubebuilder has a dockerignore for bin/
+def binary():
+    return 'CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o tilt_bin/manager main.go'
+
+installed = local("which kubebuilder")
+print("kubebuilder is present:", installed)
+
+DIRNAME = os.path.basename(os. getcwd())
+
+local(manifests() + generate())
+
+local_resource('CRD', manifests() + 'kustomize build config/crd | kubectl apply -f -', deps=["api"])
+
+local_resource('RBAC', 'kustomize build config/rbac | kubectl apply -f -', deps=["config/rbac"])
+
+k8s_yaml(yaml())
+
+deps = ['controllers', 'pkg', 'main.go']
+deps.append('api')
+
+local_resource('Watch&Compile', generate() + binary(), deps=deps, ignore=['*/*/zz_generated.deepcopy.go'])
+
+local_resource('Sample YAML', 'kustomize build ./config/samples | kubectl apply -f -', deps=["./config/samples"], resource_deps=["controller-manager"])
+
+docker_build_with_restart(IMG, '.',
+ dockerfile_contents=DOCKERFILE,
+ entrypoint='/manager',
+ only=['./tilt_bin/manager'],
+ live_update=[
+       sync('./tilt_bin/manager', '/manager'),
+   ]
+)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: wandb/controller
+  newName: controller
   newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,6 +4,10 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -18,20 +22,31 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - ingresses
   - namespaces
+  - namespaces/status
   - nodes
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/spec
+  - nodes/stats
   - pods
   - pods/log
-  - serviceaccounts
-  - services
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -45,6 +60,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -91,23 +107,80 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloud.google.com
+  resources:
+  - backendconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - ingresses
+  - ingresses/status
+  - replicasets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - networking.k8s.io
   resources:
   - ingresses
+  - ingresses/status
   - networkpolicies
   verbs:
   - create
   - delete
   - get
   - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - clusterroles
   - rolebindings
   - roles
   verbs:
@@ -115,5 +188,6 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch

--- a/config/samples/wandb.com_v1_weightsandbiases.yaml
+++ b/config/samples/wandb.com_v1_weightsandbiases.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps.wandb.com/v1
 kind: WeightsAndBiases
 metadata:
@@ -9,4 +10,7 @@ metadata:
     app.kubernetes.io/created-by: operator
   name: weightsandbiases-sample
 spec:
-  # TODO(user): Add fields here
+  values:
+    ingress:
+      install: false
+      create: false

--- a/controllers/weightsandbiases_controller.go
+++ b/controllers/weightsandbiases_controller.go
@@ -64,13 +64,21 @@ type WeightsAndBiasesReconciler struct {
 //+kubebuilder:rbac:groups=apps.wandb.com,resources=weightsandbiases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps.wandb.com,resources=weightsandbiases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps.wandb.com,resources=weightsandbiases/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=configmaps;events;persistentvolumeclaims;secrets;serviceaccounts;services,verbs=update;delete;get;list;create;watch
-//+kubebuilder:rbac:groups="",resources=nodes;namespaces;pods;pods/log;serviceaccounts;services,verbs=get;list
-//+kubebuilder:rbac:groups=apps,resources=deployments;controllerrevisions;daemonsets;replicasets;statefulsets,verbs=update;delete;get;list;create;watch
+//+kubebuilder:rbac:groups="",resources=configmaps;events;persistentvolumeclaims;secrets;serviceaccounts;services,verbs=update;delete;get;list;create;patch;watch
+//+kubebuilder:rbac:groups="",resources=endpoints;ingresses;nodes;nodes/spec;nodes/stats;nodes/metrics;nodes/proxy;namespaces;namespaces/status;replicationcontrollers;replicationcontrollers/status;resourcequotas;pods;pods/log;pods/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=deployments;controllerrevisions;daemonsets;replicasets;statefulsets,verbs=update;delete;get;list;create;patch;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;replicasets/status;statefulsets/status,verbs=get
-//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=update;delete;get;list;create;watch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=update;delete;get;list;create;watch
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=update;delete;get;list;create;watch
+//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=update;delete;get;list;patch;create;watch
+//+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=list;watch
+//+kubebuilder:rbac:groups=cloud.google.com,resources=backendconfigs,verbs=update;delete;get;list;patch;create;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;ingresses/status;networkpolicies,verbs=update;delete;get;list;create;patch;watch
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=update;delete;get;list;patch;create;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=update;delete;get;list;patch;create;watch
+//+kubebuilder:rbac:urls=/metrics,verbs=get
+
+// Deprecated/Erroneously required RBAC rules
+//+kubebuilder:rbac:groups=extensions,resources=daemonsets;deployments;replicasets;ingresses;ingresses/status,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/hack/testing-manifests/minio/minio.yaml
+++ b/hack/testing-manifests/minio/minio.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio # Change this value if you want a different namespace name
+  labels:
+    name: minio # Change this value to match metadata.name
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: minio
+  name: minio
+  namespace: minio
+spec:
+  containers:
+    - name: minio
+      image: quay.io/minio/minio:latest
+      env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+      command:
+        - /bin/bash
+        - -c
+      args:
+        - mkdir -p /data/bucket && minio server /data --console-address :9090
+      ports:
+        - containerPort: 9000
+          name: minio
+      volumeMounts:
+        - mountPath: /data
+          name: localvolume #
+  volumes:
+    - name: localvolume
+      hostPath:
+        path: /mnt/minio/data
+        type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio # Change this value to match the namespace metadata.name
+spec:
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      name: minio

--- a/hack/testing-manifests/wandb/default.yaml
+++ b/hack/testing-manifests/wandb/default.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps.wandb.com/v1
+kind: WeightsAndBiases
+metadata:
+  labels:
+    app.kubernetes.io/name: weightsandbiases
+    app.kubernetes.io/instance: weightsandbiases-sample
+    app.kubernetes.io/part-of: operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: operator
+  name: wandb-default
+spec:
+  chart:
+    url: https://charts.wandb.ai
+    name: "operator-wandb"
+    version: "0.25.1-PR338-c06d6bc"
+  values:
+    global:
+      bucket:
+        provider: "s3"
+        name: "minio.minio.svc.cluster.local:9000/bucket"
+        region: "us-east-1"
+        accessKey: "minio"
+        secretKey: "minio123"
+
+    app:
+      resources:
+        requests:
+          cpu: "100m"
+        memory: "128Mi"
+
+    parquet:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+
+    weave:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+
+    console:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+
+    ingress:
+      install: false
+      create: false
+
+    mysql:
+      install: true
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+    redis:
+      install: true
+      auth:
+        enabled: true
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"

--- a/hack/testing-manifests/wandb/default.yaml
+++ b/hack/testing-manifests/wandb/default.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     url: https://charts.wandb.ai
     name: "operator-wandb"
-    version: "0.25.1-PR338-c06d6bc"
+    version: "0.26.3"
   values:
     global:
       bucket:

--- a/tilt-settings.sample.json
+++ b/tilt-settings.sample.json
@@ -1,0 +1,9 @@
+{
+  "allowedContexts": [
+    "docker-desktop",
+    "minikube",
+    "kind-kind"
+  ],
+  "installMinio": true,
+  "installWandb": true
+}


### PR DESCRIPTION
- Tilt configs for local development
- Missing RBAC annotations that have been added to the helm chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced configuration workflow for managing Kubernetes resources and Docker image builds.
  - Added a sample deployment configuration for a Weights & Biases service with refined ingress options.
  - Introduced a new Kubernetes manifest for deploying MinIO.
  - Added a new configuration file for managing WandB resources in a Kubernetes cluster.
  - Enhanced RBAC permissions for various Kubernetes resources.

- **Chores**
  - Updated file exclusion rules for improved consistency.
  - Streamlined container image naming conventions.
  - Updated documentation to include prerequisites and setup instructions for local development.
  - Introduced a sample settings file for Tilt configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->