### PR TITLE
fix: Look for secret in namespace of wandb CR

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -19,6 +19,11 @@ settings.update(read_json(
 # Configure global watch settings with a 2-second debounce
 watch_settings(ignore=["**/.git", "**/*.out"])
 
+if k8s_context() in settings.get("allowedContexts"):
+    print("Context is allowed")
+else:
+    fail("Selected context is not in allow list")
+
 allow_k8s_contexts(settings.get("allowed_k8s_contexts"))
 
 os.putenv('PATH', './bin:' + os.getenv('PATH'))

--- a/controllers/weightsandbiases_controller.go
+++ b/controllers/weightsandbiases_controller.go
@@ -140,7 +140,7 @@ func (r *WeightsAndBiasesReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		log.Info("No active spec found.")
 	}
 
-	license := utils.GetLicense(currentActiveSpec, crdSpec, userInputSpec)
+	license := utils.GetLicense(ctx, r.Client, wandb, crdSpec, userInputSpec)
 
 	var deployerSpec *spec.Spec
 	if !r.IsAirgapped {

--- a/pkg/wandb/spec/utils/license.go
+++ b/pkg/wandb/spec/utils/license.go
@@ -2,19 +2,17 @@ package utils
 
 import (
 	"context"
-	"fmt"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/wandb/operator/pkg/wandb/spec"
 )
 
-func GetLicense(specs ...*spec.Spec) string {
-	log := ctrllog.Log.WithName("GetLicense")
+func GetLicense(ctx context.Context, k8sClient client.Client, wandb v1.Object, specs ...*spec.Spec) string {
+	log := ctrllog.FromContext(ctx).WithName("GetLicense")
 
 	// First check if license is directly provided in values
 	for _, s := range specs {
@@ -30,12 +28,6 @@ func GetLicense(specs ...*spec.Spec) string {
 	}
 
 	// Then try to get from secret if no direct license was found
-	kubeClient, err := createKubeClient()
-	if err != nil {
-		log.Error(err, "Error creating Kubernetes client")
-		return ""
-	}
-
 	for _, s := range specs {
 		if s == nil || s.Values == nil {
 			continue
@@ -43,13 +35,10 @@ func GetLicense(specs ...*spec.Spec) string {
 
 		secretName := s.Values.GetString("global.licenseSecret.name")
 		secretKey := s.Values.GetString("global.licenseSecret.key")
-		secretNamespace := s.Values.GetString("global.licenseSecret.namespace")
-		if secretNamespace == "" {
-			secretNamespace = "default"
-		}
+		secretNamespace := wandb.GetNamespace()
 
 		if secretName != "" && secretKey != "" {
-			license := getLicenseFromSecret(kubeClient, secretName, secretKey, secretNamespace)
+			license := getLicenseFromSecret(k8sClient, secretName, secretKey, secretNamespace)
 			if license != "" {
 				log.Info("License retrieved from Kubernetes secret")
 				return license
@@ -59,29 +48,11 @@ func GetLicense(specs ...*spec.Spec) string {
 	return ""
 }
 
-func createKubeClient() (client.Client, error) {
-	kubeConfig, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
-	if kubeConfig.Host == "" {
-		return nil, fmt.Errorf("invalid kubernetes configuration: empty host")
-	}
-
-	kubeClient, err := client.New(kubeConfig, client.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return kubeClient, nil
-}
-
-func getLicenseFromSecret(kubeClient client.Client, secretName, secretKey, secretNamespace string) string {
+func getLicenseFromSecret(k8sClient client.Client, secretName, secretKey, secretNamespace string) string {
 	log := ctrllog.Log.WithName("getLicenseFromSecret")
 	secret := &corev1.Secret{}
 
-	err := kubeClient.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: secretNamespace}, secret)
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: secretNamespace}, secret)
 	if err != nil {
 		log.Error(err, "Error retrieving secret")
 		return ""

--- a/pkg/wandb/spec/utils/license.go
+++ b/pkg/wandb/spec/utils/license.go
@@ -38,7 +38,7 @@ func GetLicense(ctx context.Context, k8sClient client.Client, wandb v1.Object, s
 		secretNamespace := wandb.GetNamespace()
 
 		if secretName != "" && secretKey != "" {
-			license := getLicenseFromSecret(k8sClient, secretName, secretKey, secretNamespace)
+			license := getLicenseFromSecret(ctx, k8sClient, secretName, secretKey, secretNamespace)
 			if license != "" {
 				log.Info("License retrieved from Kubernetes secret")
 				return license
@@ -48,11 +48,11 @@ func GetLicense(ctx context.Context, k8sClient client.Client, wandb v1.Object, s
 	return ""
 }
 
-func getLicenseFromSecret(k8sClient client.Client, secretName, secretKey, secretNamespace string) string {
-	log := ctrllog.Log.WithName("getLicenseFromSecret")
+func getLicenseFromSecret(ctx context.Context, k8sClient client.Client, secretName, secretKey, secretNamespace string) string {
+	log := ctrllog.FromContext(ctx).WithName("getLicenseFromSecret")
 	secret := &corev1.Secret{}
 
-	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: secretName, Namespace: secretNamespace}, secret)
+	err := k8sClient.Get(ctx, client.ObjectKey{Name: secretName, Namespace: secretNamespace}, secret)
 	if err != nil {
 		log.Error(err, "Error retrieving secret")
 		return ""

--- a/pkg/wandb/spec/utils/license_test.go
+++ b/pkg/wandb/spec/utils/license_test.go
@@ -82,6 +82,8 @@ var _ = Describe("License", func() {
 					},
 				}
 				Expect(utils.GetLicense(context.Background(), k8sClient, testWandb, testSpec)).To(Equal("test-license"))
+				err = k8sClient.Delete(context.Background(), licenseSecret)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 		Context("when the license is not set", func() {

--- a/pkg/wandb/spec/utils/license_test.go
+++ b/pkg/wandb/spec/utils/license_test.go
@@ -1,15 +1,19 @@
 package utils_test
 
 import (
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "github.com/wandb/operator/api/v1"
 	"github.com/wandb/operator/pkg/wandb/spec"
 	"github.com/wandb/operator/pkg/wandb/spec/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("License", func() {
 	Describe("GetLicense", func() {
-		Context("when the license is set", func() {
+		Context("when the license is set via values", func() {
 			It("should return the license", func() {
 				testSpec := &spec.Spec{
 					Values: map[string]interface{}{
@@ -18,7 +22,66 @@ var _ = Describe("License", func() {
 						},
 					},
 				}
-				Expect(utils.GetLicense(testSpec)).To(Equal("test-license"))
+				testWandb := &v1.WeightsAndBiases{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-name",
+					},
+				}
+				Expect(utils.GetLicense(context.Background(), k8sClient, testWandb, testSpec)).To(Equal("test-license"))
+			})
+		})
+		Context("when the license secret is specified but not present", func() {
+			It("should return an empty string", func() {
+				testSpec := &spec.Spec{
+					Values: map[string]interface{}{
+						"global": map[string]interface{}{
+							"licenseSecret": map[string]interface{}{
+								"name": "test-secret-name",
+								"key":  "license",
+							},
+						},
+					},
+				}
+				testWandb := &v1.WeightsAndBiases{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-name",
+					},
+				}
+				Expect(utils.GetLicense(context.Background(), k8sClient, testWandb, testSpec)).To(Equal(""))
+			})
+		})
+		Context("when the license is set via secret", func() {
+			It("should return the license", func() {
+				licenseSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-secret-name",
+					},
+					Data: map[string][]byte{
+						"license": []byte("test-license"),
+					},
+				}
+				err := k8sClient.Create(context.Background(), licenseSecret)
+				Expect(err).NotTo(HaveOccurred())
+				testSpec := &spec.Spec{
+					Values: map[string]interface{}{
+						"global": map[string]interface{}{
+							"licenseSecret": map[string]interface{}{
+								"name": "test-secret-name",
+								"key":  "license",
+							},
+						},
+					},
+				}
+				testWandb := &v1.WeightsAndBiases{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-name",
+					},
+				}
+				Expect(utils.GetLicense(context.Background(), k8sClient, testWandb, testSpec)).To(Equal("test-license"))
 			})
 		})
 		Context("when the license is not set", func() {
@@ -28,7 +91,13 @@ var _ = Describe("License", func() {
 						"global": map[string]interface{}{},
 					},
 				}
-				Expect(utils.GetLicense(testSpec)).To(Equal(""))
+				testWandb := &v1.WeightsAndBiases{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-name",
+					},
+				}
+				Expect(utils.GetLicense(context.Background(), k8sClient, testWandb, testSpec)).To(Equal(""))
 			})
 		})
 	})

--- a/pkg/wandb/spec/utils/utils_suite_test.go
+++ b/pkg/wandb/spec/utils/utils_suite_test.go
@@ -1,13 +1,57 @@
 package utils_test
 
 import (
+	wandbcomv1 "github.com/wandb/operator/api/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
 func TestUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Utils Suite")
 }
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = wandbcomv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
- Refactor GetLicense to use the k8s client from the controller
- Use the namespace of the wandb resource for secret location 
- Add tests for retreiving license from secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced validation for execution environments—ensuring that only approved contexts are accepted for deployment.
  - Improved license retrieval process by integrating Kubernetes context and client information.

- **Chores**
  - Streamlined the license verification process with enhanced logging and context-based operations.

- **Tests**
  - Expanded test coverage to verify environment checks and license handling, including scenarios for missing license secrets and successful retrievals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->