### PR TITLE
feat: Add reading helm username and password from a secret

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -116,8 +116,11 @@ rules:
   - cronjobs
   - jobs
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - cloud.google.com

--- a/controllers/weightsandbiases_controller.go
+++ b/controllers/weightsandbiases_controller.go
@@ -70,7 +70,7 @@ type WeightsAndBiasesReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments;controllerrevisions;daemonsets;replicasets;statefulsets,verbs=update;delete;get;list;create;patch;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;replicasets/status;statefulsets/status,verbs=get
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=update;delete;get;list;patch;create;watch
-//+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch;create;delete;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=list;watch
 //+kubebuilder:rbac:groups=cloud.google.com,resources=backendconfigs,verbs=update;delete;get;list;patch;create;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;ingresses/status;networkpolicies,verbs=update;delete;get;list;create;patch;watch

--- a/hack/testing-manifests/wandb/default.yaml
+++ b/hack/testing-manifests/wandb/default.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     url: https://charts.wandb.ai
     name: "operator-wandb"
-    version: "0.26.3"
+    version: "0.32.4"
   values:
     global:
       bucket:
@@ -60,8 +60,6 @@ spec:
 
     redis:
       install: true
-      auth:
-        enabled: true
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Helm repository credentials from Kubernetes Secrets, enhancing secure credential management.

* **Chores**
  * Expanded permissions for batch jobs and cronjobs to include creation, deletion, and patching alongside existing read and watch capabilities.
  * Updated Helm chart version and disabled Redis authentication in the default configuration.

* **Tests**
  * Introduced comprehensive tests for handling Helm repository credentials sourced from Kubernetes Secrets, covering various credential scenarios and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->