### PR TITLE
fix: Prune old helm releases

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	secretsStorageDriver = "secrets"
+	maxReleasesToKeep    = 10
 )
 
 var (
@@ -49,6 +50,7 @@ func InitConfig(namespace string) (*cli.EnvSettings, *action.Configuration, erro
 		secretsStorageDriver,
 		noopLogger,
 	)
+	config.Releases.MaxHistory = maxReleasesToKeep
 	return settings, config, err
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm release history is now limited to the 10 most recent entries, helping to manage storage and improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->