### PR TITLE
fix: Prune old helm releases, for real

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -158,6 +158,7 @@ func (c *ActionableChart) Rollback(version int) error {
 func (c *ActionableChart) Upgrade(chart *chart.Chart, values map[string]interface{}) (*release.Release, error) {
 	client := action.NewUpgrade(c.config)
 	client.Namespace = c.namespace
+	client.MaxHistory = maxReleasesToKeep
 	return client.Run(c.releaseName, chart, values)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted upgrade process to retain a maximum of 10 release revisions during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->