### PR TITLE
fix: Tiltfile consolidattion of third-party operators, add readiness gates, and improve dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tilt-settings.json
 
 # Local webhook development certificates
 .local-webhook-certs/
+
+# various util artifacts
+.k8s-images

--- a/Tiltfile
+++ b/Tiltfile
@@ -212,6 +212,15 @@ if settings.get("installTelemetry"):
         resource_deps=["third-party-operators"],
         labels=["Telemetry"],
     )
+    local_resource(
+        'vm-operator-ready',
+        'kubectl rollout status deployment ' +
+        '-n wandb-operator ' +
+        '-l app.kubernetes.io/name=victoria-metrics-operator ' +
+        '--timeout=120s',
+        resource_deps=["vm-crds-ready"],
+        labels=["Telemetry"],
+    )
     k8s_yaml('./hack/testing-manifests/telemetry/victoria-dev.yaml')
     k8s_resource(
         new_name='Victoria-Metrics',
@@ -219,7 +228,7 @@ if settings.get("installTelemetry"):
             'victoria-instance:vmsingle',
             'victoria-agent:vmagent',
         ],
-        resource_deps=["vm-crds-ready"],
+        resource_deps=["vm-operator-ready"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -227,7 +236,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-logs:vlsingle',
         ],
-        resource_deps=["vm-crds-ready"],
+        resource_deps=["vm-operator-ready"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -235,7 +244,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-traces:vtsingle',
         ],
-        resource_deps=["vm-crds-ready"],
+        resource_deps=["vm-operator-ready"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/wandb-otel-connection-dev.yaml')

--- a/Tiltfile
+++ b/Tiltfile
@@ -107,6 +107,17 @@ helm_resource(
 k8s_yaml(local('kustomize build config/tilt-dev'))
 
 k8s_resource(
+    new_name='Operator-Certs',
+    objects=[
+        'operator-system:namespace',
+        'operator-metrics-certs:certificate',
+        'operator-serving-cert:certificate',
+        'operator-selfsigned-issuer:issuer',
+    ],
+    labels=["Operator-Resources"],
+)
+
+k8s_resource(
     new_name='Application CRD',
     objects=['applications.apps.wandb.com:customresourcedefinition'],
     resource_deps=["manifests", "generate"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -180,6 +180,27 @@ if settings.get("installWandb"):
     )
 
 if settings.get("installTelemetry"):
+    local_resource(
+        'vm-crds-ready',
+        'kubectl wait --for=condition=established --timeout=120s ' +
+        'crd/vmsingles.operator.victoriametrics.com ' +
+        'crd/vmagents.operator.victoriametrics.com ' +
+        'crd/vlsingles.operator.victoriametrics.com ' +
+        'crd/vtsingles.operator.victoriametrics.com ' +
+        'crd/vmservicescrapes.operator.victoriametrics.com ' +
+        'crd/vmpodscrapes.operator.victoriametrics.com ' +
+        'crd/vmnodescrapes.operator.victoriametrics.com',
+        resource_deps=["third-party-operators"],
+        labels=["Telemetry"],
+    )
+    local_resource(
+        'grafana-crds-ready',
+        'kubectl wait --for=condition=established --timeout=120s ' +
+        'crd/grafanas.grafana.integreatly.org ' +
+        'crd/grafanadatasources.grafana.integreatly.org',
+        resource_deps=["third-party-operators"],
+        labels=["Telemetry"],
+    )
     k8s_yaml('./hack/testing-manifests/telemetry/victoria-dev.yaml')
     k8s_resource(
         new_name='Victoria-Metrics',
@@ -187,7 +208,7 @@ if settings.get("installTelemetry"):
             'victoria-instance:vmsingle',
             'victoria-agent:vmagent',
         ],
-        resource_deps=["third-party-operators"],
+        resource_deps=["vm-crds-ready"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -195,7 +216,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-logs:vlsingle',
         ],
-        resource_deps=["third-party-operators"],
+        resource_deps=["vm-crds-ready"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -203,7 +224,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-traces:vtsingle',
         ],
-        resource_deps=["third-party-operators"],
+        resource_deps=["vm-crds-ready"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/wandb-otel-connection-dev.yaml')
@@ -221,7 +242,7 @@ if settings.get("installTelemetry"):
         objects=[
             'kubelet-cadvisor:vmnodescrape',
         ],
-        resource_deps=["Victoria-Metrics"],
+        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/operator-metrics-dev.yaml')
@@ -233,7 +254,7 @@ if settings.get("installTelemetry"):
             'grafana-operator:vmservicescrape',
             'victoria-metrics-operator:vmservicescrape',
         ],
-        resource_deps=["Victoria-Metrics"],
+        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/infra-metrics-dev.yaml')
@@ -246,7 +267,7 @@ if settings.get("installTelemetry"):
             'minio-tenant:vmpodscrape',
             'redis:vmpodscrape',
         ],
-        resource_deps=["Victoria-Metrics"],
+        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/grafana-dev.yaml')
@@ -255,7 +276,7 @@ if settings.get("installTelemetry"):
         objects=[
             'grafana:grafana',
         ],
-        resource_deps=["third-party-operators"],
+        resource_deps=["grafana-crds-ready"],
         port_forwards="3000:3000",
         labels=["Telemetry"],
     )
@@ -266,7 +287,7 @@ if settings.get("installTelemetry"):
             'victoria-logs:grafanadatasource',
             'victoria-traces:grafanadatasource',
         ],
-        resource_deps=["Grafana", "Victoria-Metrics", "Victoria-Logs", "Victoria-Traces"],
+        resource_deps=["grafana-crds-ready", "Grafana", "Victoria-Metrics", "Victoria-Logs", "Victoria-Traces"],
         labels=["Telemetry"],
     )
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -137,6 +137,15 @@ k8s_resource(
     labels=["Operator-Resources"],
 )
 
+local_resource(
+    'operator-crds-ready',
+    'kubectl wait --for=condition=established --timeout=120s ' +
+    'crd/applications.apps.wandb.com ' +
+    'crd/weightsandbiases.apps.wandb.com',
+    resource_deps=["Application CRD", "Wandb CRD"],
+    labels=["Operator-Resources"],
+)
+
 k8s_resource(
     'operator-controller-manager',
     'operator-controller-manager',
@@ -145,7 +154,7 @@ k8s_resource(
         'operator-validating-webhook-configuration:validatingwebhookconfiguration',
         'operator-controller-manager:serviceaccount',
     ],
-    resource_deps=["manifests", "generate", "third-party-operators"],
+    resource_deps=["manifests", "generate", "operator-crds-ready", "third-party-operators"],
     labels=["Operator-Resources"],
 )
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -275,6 +275,8 @@ if settings.get("installTelemetry"):
             'kafka-brokers:vmpodscrape',
             'minio-tenant:vmpodscrape',
             'redis:vmpodscrape',
+            'clickhouse-metrics:service',
+            'clickhouse:vmservicescrape',
         ],
         resource_deps=["vm-crds-ready", "Victoria-Metrics"],
         labels=["Telemetry"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -109,12 +109,14 @@ k8s_yaml(local('kustomize build config/tilt-dev'))
 k8s_resource(
     new_name='Application CRD',
     objects=['applications.apps.wandb.com:customresourcedefinition'],
+    resource_deps=["manifests", "generate"],
     labels=["Operator-Resources"],
 )
 
 k8s_resource(
     new_name='Wandb CRD',
     objects=['weightsandbiases.apps.wandb.com:customresourcedefinition'],
+    resource_deps=["manifests", "generate"],
     labels=["Operator-Resources", "third-party-operators"],
 )
 k8s_resource(

--- a/Tiltfile
+++ b/Tiltfile
@@ -114,6 +114,7 @@ k8s_resource(
         'operator-serving-cert:certificate',
         'operator-selfsigned-issuer:issuer',
     ],
+    resource_deps=["cert-manager"],
     labels=["Operator-Resources"],
 )
 
@@ -128,6 +129,7 @@ k8s_resource(
     new_name='Wandb CRD',
     objects=['weightsandbiases.apps.wandb.com:customresourcedefinition'],
     resource_deps=["manifests", "generate"],
+    # wandb-operator is disabled in this Tilt setup; label is for 3rd party operator CRD grouping only
     labels=["Operator-Resources", "third-party-operators"],
 )
 k8s_resource(
@@ -147,6 +149,7 @@ k8s_resource(
         'operator-weightsandbiases-viewer-role:clusterrole',
         'operator-metrics-auth-rolebinding:clusterrolebinding',
     ],
+    resource_deps=["manifests", "generate"],
     labels=["Operator-Resources"],
 )
 
@@ -167,7 +170,8 @@ k8s_resource(
         'operator-validating-webhook-configuration:validatingwebhookconfiguration',
         'operator-controller-manager:serviceaccount',
     ],
-    resource_deps=["manifests", "generate", "operator-crds-ready", "third-party-operators"],
+    # manifests/generate transitively satisfied via operator-crds-ready → Application CRD / Wandb CRD
+    resource_deps=["operator-crds-ready", "third-party-operators"],
     labels=["Operator-Resources"],
 )
 
@@ -273,7 +277,8 @@ if settings.get("installTelemetry"):
         objects=[
             'kubelet-cadvisor:vmnodescrape',
         ],
-        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
+        # vm-crds-ready transitively satisfied via Victoria-Metrics → vm-operator-ready → vm-crds-ready
+        resource_deps=["Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/operator-metrics-dev.yaml')
@@ -285,7 +290,8 @@ if settings.get("installTelemetry"):
             'grafana-operator:vmservicescrape',
             'victoria-metrics-operator:vmservicescrape',
         ],
-        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
+        # vm-crds-ready transitively satisfied via Victoria-Metrics → vm-operator-ready → vm-crds-ready
+        resource_deps=["Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/infra-metrics-dev.yaml')
@@ -300,7 +306,8 @@ if settings.get("installTelemetry"):
             'clickhouse-metrics:service',
             'clickhouse:vmservicescrape',
         ],
-        resource_deps=["vm-crds-ready", "Victoria-Metrics"],
+        # vm-crds-ready transitively satisfied via Victoria-Metrics → vm-operator-ready → vm-crds-ready
+        resource_deps=["Victoria-Metrics"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/grafana-dev.yaml')

--- a/Tiltfile
+++ b/Tiltfile
@@ -36,7 +36,7 @@ allow_k8s_contexts(settings.get("allowed_k8s_contexts"))
 os.putenv('PATH', './bin:' + os.getenv('PATH'))
 
 load('ext://restart_process', 'docker_build_with_restart')
-load('ext://helm_resource', 'helm_resource', 'helm_repo')
+load('ext://helm_resource', 'helm_resource')
 load('ext://cert_manager', 'deploy_cert_manager')
 
 DOCKERFILE = '''
@@ -86,89 +86,21 @@ local_resource("generate", generate(), labels=["Operator-Resources"])
 
 deploy_cert_manager()
 
-helm_repo(
-    'mysql-operator-repo',
-    'https://mysql.github.io/mysql-operator',
+local_resource(
+    'helm-dep-update',
+    'helm dependency update ./deploy/operator',
     labels=["Helm-Repos"],
 )
 
 helm_resource(
-    'mysql-operator',
-    chart='mysql-operator-repo/mysql-operator',
-    resource_deps=['mysql-operator-repo'],
-    labels=["Third-Party-Operators"],
-    flags=['--set-string=image.tag=8.4.7-2.1.9']
-)
-
-helm_repo(
-    'redis-operator-repo',
-    'https://ot-container-kit.github.io/helm-charts/',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'redis-operator',
-    chart='redis-operator-repo/redis-operator',
-    resource_deps=['redis-operator-repo'],
-    labels=["Third-Party-Operators"],
-)
-
-helm_repo(
-    'strimzi-repo',
-    'https://strimzi.io/charts/',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'kafka-operator',
-    chart='strimzi-repo/strimzi-kafka-operator',
-    resource_deps=['strimzi-repo'],
-    labels=["Third-Party-Operators"],
-)
-
-helm_repo(
-    'minio-repo',
-    'https://operator.min.io',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'minio-operator',
-    chart='minio-repo/operator',
-    resource_deps=['minio-repo'],
-    labels=["Third-Party-Operators"],
-)
-
-helm_repo(
-    'clickhouse-repo',
-    'https://helm.altinity.com',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'clickhouse-operator',
-    chart='clickhouse-repo/altinity-clickhouse-operator',
-    resource_deps=['clickhouse-repo'],
-    labels=["Third-Party-Operators"],
-)
-
-helm_repo(
-    'victoria-metrics-repo',
-    'https://victoriametrics.github.io/helm-charts/',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'victoria-metrics-operator',
-    chart='victoria-metrics-repo/victoria-metrics-operator',
-    resource_deps=['victoria-metrics-repo'],
-    labels=["Third-Party-Operators"],
-)
-
-helm_repo(
-    'grafana-repo',
-    'https://grafana.github.io/helm-charts',
-    labels=["Helm-Repos"],
-)
-helm_resource(
-    'grafana-operator',
-    chart='grafana-repo/grafana-operator',
-    resource_deps=['grafana-repo'],
+    'third-party-operators',
+    chart='./deploy/operator',
+    resource_deps=['helm-dep-update'],
+    namespace='wandb-operator',
+    flags=[
+        '--set=wandb-operator.enabled=false',
+        '--create-namespace',
+    ],
     labels=["Third-Party-Operators"],
 )
 
@@ -183,7 +115,7 @@ k8s_resource(
 k8s_resource(
     new_name='Wandb CRD',
     objects=['weightsandbiases.apps.wandb.com:customresourcedefinition'],
-    labels=["Operator-Resources"],
+    labels=["Operator-Resources", "third-party-operators"],
 )
 k8s_resource(
     new_name='RBAC',
@@ -213,7 +145,7 @@ k8s_resource(
         'operator-validating-webhook-configuration:validatingwebhookconfiguration',
         'operator-controller-manager:serviceaccount',
     ],
-    resource_deps=["manifests", "generate", "redis-operator", "kafka-operator", "minio-operator", "clickhouse-operator"],
+    resource_deps=["manifests", "generate", "third-party-operators"],
     labels=["Operator-Resources"],
 )
 
@@ -255,7 +187,7 @@ if settings.get("installTelemetry"):
             'victoria-instance:vmsingle',
             'victoria-agent:vmagent',
         ],
-        resource_deps=["victoria-metrics-operator"],
+        resource_deps=["third-party-operators"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -263,7 +195,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-logs:vlsingle',
         ],
-        resource_deps=["victoria-metrics-operator"],
+        resource_deps=["third-party-operators"],
         labels=["Telemetry"],
     )
     k8s_resource(
@@ -271,7 +203,7 @@ if settings.get("installTelemetry"):
         objects=[
             'victoria-traces:vtsingle',
         ],
-        resource_deps=["victoria-metrics-operator"],
+        resource_deps=["third-party-operators"],
         labels=["Telemetry"],
     )
     k8s_yaml('./hack/testing-manifests/telemetry/wandb-otel-connection-dev.yaml')
@@ -323,7 +255,7 @@ if settings.get("installTelemetry"):
         objects=[
             'grafana:grafana',
         ],
-        resource_deps=["grafana-operator"],
+        resource_deps=["third-party-operators"],
         port_forwards="3000:3000",
         labels=["Telemetry"],
     )

--- a/Tiltfile
+++ b/Tiltfile
@@ -114,7 +114,8 @@ k8s_resource(
         'operator-serving-cert:certificate',
         'operator-selfsigned-issuer:issuer',
     ],
-    resource_deps=["cert-manager"],
+    # deploy_cert_manager() runs local() commands and registers no Tilt resource,
+    # so a resource_dep cannot be declared here. Tilt retries on failure.
     labels=["Operator-Resources"],
 )
 

--- a/deploy/operator/Chart.lock
+++ b/deploy/operator/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: 5.21.4
-digest: sha256:49b17dbf78551c3e5d5357737af85eb0825e6ff26afd37a78197e47ba03afdb5
-generated: "2026-02-09T20:30:50.180745-08:00"
+digest: sha256:a2a513523e30dd186ad3303f83561c645b9f965555d74780e1449da9f44f41a0
+generated: "2026-02-25T15:50:27.559416-06:00"

--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -14,6 +14,7 @@ dependencies:
     version: 0.11.8
     alias: wandb-operator
     repository: https://charts.wandb.ai/
+    condition: wandb-operator.enabled
   - name: mysql-operator
     version: 2.2.7
     repository: https://mysql.github.io/mysql-operator/

--- a/deploy/operator/templates/certificates.yaml
+++ b/deploy/operator/templates/certificates.yaml
@@ -1,3 +1,4 @@
+{{- if not (eq (index .Values "wandb-operator" "enabled") false) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -20,3 +21,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+{{- end }}

--- a/deploy/operator/templates/wandb-cr.yaml
+++ b/deploy/operator/templates/wandb-cr.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.wandb.install }}
+{{ if and .Values.wandb.install (not (eq (index .Values "wandb-operator" "enabled") false)) }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/deploy/operator/templates/webhooks.yaml
+++ b/deploy/operator/templates/webhooks.yaml
@@ -1,3 +1,4 @@
+{{- if not (eq (index .Values "wandb-operator" "enabled") false) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -94,3 +95,4 @@ webhooks:
         resources:
           - weightsandbiases
     sideEffects: None
+{{- end }}

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -7,10 +7,13 @@ active when `installTelemetry: true` and Wandb is only active when
 ```mermaid
 graph TD
     %% ── Bootstrapping ──────────────────────────────────────────────
-    manifests["manifests\n(Operator-Resources)"]
-    generate["generate\n(Operator-Resources)"]
     cert_manager["cert-manager\n(ext)"]
     helm_dep_update["helm-dep-update\n(Helm-Repos)"]
+
+    subgraph codegen["Code Generation"]
+        manifests["manifests"]
+        generate["generate"]
+    end
 
     %% ── Third-Party Operators ──────────────────────────────────────
     third_party["third-party-operators\n(Third-Party-Operators)"]
@@ -21,25 +24,21 @@ graph TD
     wandb_crd["Wandb CRD\n(Operator-Resources)"]
     rbac["RBAC\n(Operator-Resources)"]
     operator_certs["Operator-Certs\n(Operator-Resources)"]
-    manifests --> app_crd
-    generate  --> app_crd
-    manifests --> wandb_crd
-    generate  --> wandb_crd
+    codegen --> app_crd
+    codegen --> wandb_crd
 
     %% ── CRD Readiness Gate ─────────────────────────────────────────
     crds_ready["operator-crds-ready\n(Operator-Resources)"]
-    app_crd  --> crds_ready
+    app_crd   --> crds_ready
     wandb_crd --> crds_ready
 
     %% ── Operator Controller ────────────────────────────────────────
     watch_compile["Watch&Compile\n(Operator-Resources)"]
     controller["operator-controller-manager\n(Operator-Resources)"]
-    manifests       --> watch_compile
-    generate        --> watch_compile
-    manifests       --> controller
-    generate        --> controller
-    crds_ready      --> controller
-    third_party     --> controller
+    codegen     --> watch_compile
+    codegen     --> controller
+    crds_ready  --> controller
+    third_party --> controller
 
     %% ── Webhook Readiness ──────────────────────────────────────────
     webhook_ready["webhook-ready\n(Operator-Resources)"]

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -86,6 +86,7 @@ graph TD
     operator_certs["Operator-Certs\n(Operator-Resources)"]
     codegen ==> app_crd
     codegen ==> wandb_crd
+    codegen ==> rbac
 
     %% ── CRD Readiness Gate ─────────────────────────────────────────
     crds_ready["operator-crds-ready\n(Operator-Resources)"]
@@ -96,7 +97,6 @@ graph TD
     watch_compile["Watch&Compile\n(Operator-Resources)"]
     controller["operator-controller-manager\n(Operator-Resources)"]
     codegen     ==> watch_compile
-    codegen     ==> controller
     crds_ready  --> controller
     third_party --> controller
 
@@ -116,7 +116,7 @@ graph TD
     third_party --> grafana_crds
     vm_crds     --> vm_operator
 
-    %% ── Victoria Metrics Stack ─────────────────────────────────────
+    %% ── Victoria Stack ─────────────────────────────────────────────
     subgraph victoria_stack["Victoria Stack"]
         victoria_metrics["Victoria-Metrics\n(Telemetry)"]
         victoria_logs["Victoria-Logs\n(Telemetry)"]
@@ -130,11 +130,8 @@ graph TD
     op_metrics["Operator-Metrics\n(Telemetry)"]
     infra_metrics["Infrastructure-Metrics\n(Telemetry)"]
     victoria_stack   ==> otel
-    vm_crds          --> kube_metrics
     victoria_metrics --> kube_metrics
-    vm_crds          --> op_metrics
     victoria_metrics --> op_metrics
-    vm_crds          --> infra_metrics
     victoria_metrics --> infra_metrics
 
     %% ── Grafana Stack ──────────────────────────────────────────────

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -4,6 +4,66 @@ Resources shown with their labels in parentheses. Telemetry resources are only
 active when `installTelemetry: true` and Wandb is only active when
 `installWandb: true` in `tilt-settings.json`.
 
+## Agent Instructions
+
+To regenerate this graph, read `Tiltfile` at the repo root and apply the rules below.
+
+### Deriving Nodes and Edges
+
+Each `local_resource(name, ...)`, `k8s_resource(new_name=name, ...)`, and
+`helm_resource(name, ...)` call defines a node. Draw one directed edge per entry
+in its `resource_deps=[...]` list. `deploy_cert_manager()` produces a node named
+`cert-manager`.
+
+### Node Label Format
+
+```
+nodeId["resource-name\n(Label-Group)"]
+```
+
+Use the Tilt resource name as display text and the first value of `labels=[...]`
+as the group. Node IDs are snake_case versions of the resource name.
+
+### Subgraphs
+
+Group nodes into a `subgraph` when they share identical incoming and outgoing
+edges — i.e., every parent points to all members and all members point to the
+same children. Replace the redundant per-node edges with single edges to/from
+the subgraph.
+
+Current subgraphs:
+- `codegen["Code Generation"]` — `manifests`, `generate`
+- `victoria_stack["Victoria Stack"]` — `Victoria-Metrics`, `Victoria-Logs`, `Victoria-Traces`
+
+### Arrow Styles
+
+- `-->` for edges between individual nodes
+- `==>` (thick) for any edge where either endpoint is a subgraph
+
+### Conditional Resources
+
+Include all resources in the graph unconditionally. The intro text above the
+diagram already describes the `installTelemetry` / `installWandb` conditions.
+Use `%% comments` to mark conditional sections in the Mermaid source.
+
+### Class Assignments
+
+| Class        | Color  | Assigned to |
+|--------------|--------|-------------|
+| `bootstrap`  | grey   | `cert-manager`, `helm-dep-update`, `manifests`, `generate` |
+| `operator`   | blue   | CRDs, RBAC, certs, controller, webhook, `Watch&Compile` |
+| `thirdparty` | green  | `third-party-operators` |
+| `gate`       | yellow | readiness-gate resources (`*-ready`, `*-crds-ready`) |
+| `telemetry`  | pink   | all telemetry stack resources |
+| `wandb`      | purple | `Wandb` CR |
+
+### Transitive Dependencies
+
+Do not draw edges that are transitively implied by another declared dep.
+When a dep is omitted from `resource_deps` for this reason, the Tiltfile
+contains a comment of the form `# X transitively satisfied via A → B → C`.
+Do not add those edges to the graph.
+
 ```mermaid
 graph TD
     %% ── Bootstrapping ──────────────────────────────────────────────

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -24,8 +24,8 @@ graph TD
     wandb_crd["Wandb CRD\n(Operator-Resources)"]
     rbac["RBAC\n(Operator-Resources)"]
     operator_certs["Operator-Certs\n(Operator-Resources)"]
-    codegen --> app_crd
-    codegen --> wandb_crd
+    codegen ==> app_crd
+    codegen ==> wandb_crd
 
     %% ── CRD Readiness Gate ─────────────────────────────────────────
     crds_ready["operator-crds-ready\n(Operator-Resources)"]
@@ -35,8 +35,8 @@ graph TD
     %% ── Operator Controller ────────────────────────────────────────
     watch_compile["Watch&Compile\n(Operator-Resources)"]
     controller["operator-controller-manager\n(Operator-Resources)"]
-    codegen     --> watch_compile
-    codegen     --> controller
+    codegen     ==> watch_compile
+    codegen     ==> controller
     crds_ready  --> controller
     third_party --> controller
 
@@ -57,19 +57,19 @@ graph TD
     vm_crds     --> vm_operator
 
     %% ── Victoria Metrics Stack ─────────────────────────────────────
-    subgraph victoria_stack["Victoria-* Stack"]
+    subgraph victoria_stack["Victoria Stack"]
         victoria_metrics["Victoria-Metrics\n(Telemetry)"]
         victoria_logs["Victoria-Logs\n(Telemetry)"]
         victoria_traces["Victoria-Traces\n(Telemetry)"]
     end
-    vm_operator --> victoria_stack
+    vm_operator ==> victoria_stack
 
     %% ── Telemetry Dependents ───────────────────────────────────────
     otel["OTEL-Connection-Secret\n(Telemetry)"]
     kube_metrics["Kubernetes-Metrics\n(Telemetry)"]
     op_metrics["Operator-Metrics\n(Telemetry)"]
     infra_metrics["Infrastructure-Metrics\n(Telemetry)"]
-    victoria_stack   --> otel
+    victoria_stack   ==> otel
     vm_crds          --> kube_metrics
     victoria_metrics --> kube_metrics
     vm_crds          --> op_metrics
@@ -83,7 +83,7 @@ graph TD
     grafana_crds   --> grafana
     grafana_crds   --> grafana_ds
     grafana        --> grafana_ds
-    victoria_stack --> grafana_ds
+    victoria_stack ==> grafana_ds
 
     %% ── Styles ─────────────────────────────────────────────────────
     classDef bootstrap  fill:#f5f5f5,stroke:#999

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -1,0 +1,107 @@
+# Tilt Resource Dependency Graph
+
+Resources shown with their labels in parentheses. Telemetry resources are only
+active when `installTelemetry: true` and Wandb is only active when
+`installWandb: true` in `tilt-settings.json`.
+
+```mermaid
+graph TD
+    %% ── Bootstrapping ──────────────────────────────────────────────
+    manifests["manifests\n(Operator-Resources)"]
+    generate["generate\n(Operator-Resources)"]
+    cert_manager["cert-manager\n(ext)"]
+    helm_dep_update["helm-dep-update\n(Helm-Repos)"]
+
+    %% ── Third-Party Operators ──────────────────────────────────────
+    third_party["third-party-operators\n(Third-Party-Operators)"]
+    helm_dep_update --> third_party
+
+    %% ── Operator CRDs & RBAC ───────────────────────────────────────
+    app_crd["Application CRD\n(Operator-Resources)"]
+    wandb_crd["Wandb CRD\n(Operator-Resources)"]
+    rbac["RBAC\n(Operator-Resources)"]
+    operator_certs["Operator-Certs\n(Operator-Resources)"]
+    manifests --> app_crd
+    generate  --> app_crd
+    manifests --> wandb_crd
+    generate  --> wandb_crd
+
+    %% ── CRD Readiness Gate ─────────────────────────────────────────
+    crds_ready["operator-crds-ready\n(Operator-Resources)"]
+    app_crd  --> crds_ready
+    wandb_crd --> crds_ready
+
+    %% ── Operator Controller ────────────────────────────────────────
+    watch_compile["Watch&Compile\n(Operator-Resources)"]
+    controller["operator-controller-manager\n(Operator-Resources)"]
+    manifests       --> watch_compile
+    generate        --> watch_compile
+    manifests       --> controller
+    generate        --> controller
+    crds_ready      --> controller
+    third_party     --> controller
+
+    %% ── Webhook Readiness ──────────────────────────────────────────
+    webhook_ready["webhook-ready\n(Operator-Resources)"]
+    controller --> webhook_ready
+
+    %% ── Wandb CR (installWandb) ────────────────────────────────────
+    wandb["Wandb\n(Operator-Resources)"]
+    webhook_ready --> wandb
+
+    %% ── Telemetry: CRD & Operator Gates ───────────────────────────
+    vm_crds["vm-crds-ready\n(Telemetry)"]
+    grafana_crds["grafana-crds-ready\n(Telemetry)"]
+    vm_operator["vm-operator-ready\n(Telemetry)"]
+    third_party --> vm_crds
+    third_party --> grafana_crds
+    vm_crds     --> vm_operator
+
+    %% ── Victoria Metrics Stack ─────────────────────────────────────
+    victoria_metrics["Victoria-Metrics\n(Telemetry)"]
+    victoria_logs["Victoria-Logs\n(Telemetry)"]
+    victoria_traces["Victoria-Traces\n(Telemetry)"]
+    vm_operator --> victoria_metrics
+    vm_operator --> victoria_logs
+    vm_operator --> victoria_traces
+
+    %% ── Telemetry Dependents ───────────────────────────────────────
+    otel["OTEL-Connection-Secret\n(Telemetry)"]
+    kube_metrics["Kubernetes-Metrics\n(Telemetry)"]
+    op_metrics["Operator-Metrics\n(Telemetry)"]
+    infra_metrics["Infrastructure-Metrics\n(Telemetry)"]
+    victoria_metrics --> otel
+    victoria_logs    --> otel
+    victoria_traces  --> otel
+    vm_crds          --> kube_metrics
+    victoria_metrics --> kube_metrics
+    vm_crds          --> op_metrics
+    victoria_metrics --> op_metrics
+    vm_crds          --> infra_metrics
+    victoria_metrics --> infra_metrics
+
+    %% ── Grafana Stack ──────────────────────────────────────────────
+    grafana["Grafana\n(Telemetry)"]
+    grafana_ds["Grafana-Datasources\n(Telemetry)"]
+    grafana_crds     --> grafana
+    grafana_crds     --> grafana_ds
+    grafana          --> grafana_ds
+    victoria_metrics --> grafana_ds
+    victoria_logs    --> grafana_ds
+    victoria_traces  --> grafana_ds
+
+    %% ── Styles ─────────────────────────────────────────────────────
+    classDef bootstrap  fill:#f5f5f5,stroke:#999
+    classDef operator   fill:#dbeafe,stroke:#3b82f6
+    classDef thirdparty fill:#dcfce7,stroke:#16a34a
+    classDef gate       fill:#fef9c3,stroke:#ca8a04
+    classDef telemetry  fill:#fce7f3,stroke:#db2777
+    classDef wandb      fill:#ede9fe,stroke:#7c3aed
+
+    class manifests,generate,cert_manager,helm_dep_update bootstrap
+    class app_crd,wandb_crd,rbac,operator_certs,watch_compile,controller,webhook_ready operator
+    class third_party thirdparty
+    class crds_ready,vm_crds,grafana_crds,vm_operator gate
+    class victoria_metrics,victoria_logs,victoria_traces,otel,kube_metrics,op_metrics,infra_metrics,grafana,grafana_ds telemetry
+    class wandb wandb
+```

--- a/docs/design/wandb_v2/tilt.md
+++ b/docs/design/wandb_v2/tilt.md
@@ -57,21 +57,19 @@ graph TD
     vm_crds     --> vm_operator
 
     %% ── Victoria Metrics Stack ─────────────────────────────────────
-    victoria_metrics["Victoria-Metrics\n(Telemetry)"]
-    victoria_logs["Victoria-Logs\n(Telemetry)"]
-    victoria_traces["Victoria-Traces\n(Telemetry)"]
-    vm_operator --> victoria_metrics
-    vm_operator --> victoria_logs
-    vm_operator --> victoria_traces
+    subgraph victoria_stack["Victoria-* Stack"]
+        victoria_metrics["Victoria-Metrics\n(Telemetry)"]
+        victoria_logs["Victoria-Logs\n(Telemetry)"]
+        victoria_traces["Victoria-Traces\n(Telemetry)"]
+    end
+    vm_operator --> victoria_stack
 
     %% ── Telemetry Dependents ───────────────────────────────────────
     otel["OTEL-Connection-Secret\n(Telemetry)"]
     kube_metrics["Kubernetes-Metrics\n(Telemetry)"]
     op_metrics["Operator-Metrics\n(Telemetry)"]
     infra_metrics["Infrastructure-Metrics\n(Telemetry)"]
-    victoria_metrics --> otel
-    victoria_logs    --> otel
-    victoria_traces  --> otel
+    victoria_stack   --> otel
     vm_crds          --> kube_metrics
     victoria_metrics --> kube_metrics
     vm_crds          --> op_metrics
@@ -82,12 +80,10 @@ graph TD
     %% ── Grafana Stack ──────────────────────────────────────────────
     grafana["Grafana\n(Telemetry)"]
     grafana_ds["Grafana-Datasources\n(Telemetry)"]
-    grafana_crds     --> grafana
-    grafana_crds     --> grafana_ds
-    grafana          --> grafana_ds
-    victoria_metrics --> grafana_ds
-    victoria_logs    --> grafana_ds
-    victoria_traces  --> grafana_ds
+    grafana_crds   --> grafana
+    grafana_crds   --> grafana_ds
+    grafana        --> grafana_ds
+    victoria_stack --> grafana_ds
 
     %% ── Styles ─────────────────────────────────────────────────────
     classDef bootstrap  fill:#f5f5f5,stroke:#999

--- a/hack/scripts/kind-images-manager.sh
+++ b/hack/scripts/kind-images-manager.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGES_FILE=".k8s-images"
+
+cmd_scrape() {
+    kubectl get pods -A \
+        -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}{end}{range .spec.initContainers[*]}{.image}{"\n"}{end}{end}' \
+        | sort -u \
+        > "$IMAGES_FILE"
+    echo "Wrote $(wc -l < "$IMAGES_FILE") images to $IMAGES_FILE"
+}
+
+cmd_load() {
+    if [[ ! -f "$IMAGES_FILE" ]]; then
+        echo "error: $IMAGES_FILE not found — run 'scrape' first" >&2
+        exit 1
+    fi
+
+    local context
+    context=$(kubectl config current-context)
+
+    if [[ "$context" != kind-* ]]; then
+        echo "error: current kube context '$context' does not start with 'kind-'" >&2
+        exit 1
+    fi
+
+    local cluster="${context#kind-}"
+
+    local failed=()
+
+    echo "Loading images into kind cluster '$cluster'..."
+    while IFS= read -r image; do
+        [[ -z "$image" ]] && continue
+        echo "  $image"
+        if ! kind load docker-image "$image" --name "$cluster"; then
+            echo "  warning: failed to load $image" >&2
+            failed+=("$image")
+        fi
+    done < "$IMAGES_FILE"
+
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "" >&2
+        echo "Failed to load ${#failed[@]} image(s):" >&2
+        for image in "${failed[@]}"; do
+            echo "  $image" >&2
+        done
+        exit 1
+    fi
+
+    echo "Done."
+}
+
+cmd_pull() {
+    if [[ ! -f "$IMAGES_FILE" ]]; then
+        echo "error: $IMAGES_FILE not found — run 'scrape' first" >&2
+        exit 1
+    fi
+
+    local failed=()
+
+    echo "Pulling images..."
+    while IFS= read -r image; do
+        [[ -z "$image" ]] && continue
+        echo "  $image"
+        if ! docker pull "$image"; then
+            echo "  warning: failed to pull $image" >&2
+            failed+=("$image")
+        fi
+    done < "$IMAGES_FILE"
+
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "" >&2
+        echo "Failed to pull ${#failed[@]} image(s):" >&2
+        for image in "${failed[@]}"; do
+            echo "  $image" >&2
+        done
+        exit 1
+    fi
+
+    echo "Done."
+}
+
+case "${1:-}" in
+    scrape)  cmd_scrape ;;
+    pull)    cmd_pull ;;
+    load)    cmd_load ;;
+    *)
+        echo "Usage: $(basename "$0") <scrape|pull|load>" >&2
+        echo ""
+        echo "Keep docker images cached on the host and loads them into Kind."
+        echo "It uses the k8s current context, if named 'kind-*', as the Kind cluster."
+        echo "This is helpful if you run into rate-limiting problem with a repository."
+        echo ""
+        echo "scrape: copies image names from kind cluster into .k8s-images file"
+        echo "pull:   pulls images named .k8s-images file into host's docker"
+        echo "load:   loads images named .k8s-images from host's docker into Kind cluster"
+        exit 1
+        ;;
+esac

--- a/hack/testing-manifests/server-manifest/0.78.0-pre.yaml
+++ b/hack/testing-manifests/server-manifest/0.78.0-pre.yaml
@@ -353,7 +353,7 @@ applications:
   - name: anaconda2
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/anaconda2
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     ports:
       - containerPort: 8080
         name: anaconda2
@@ -400,7 +400,7 @@ applications:
             type: mysql
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - gorilla
     ports:
@@ -431,7 +431,7 @@ applications:
       - gorillaOnprem
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: filemeta
     args:
       - filemeta
@@ -443,7 +443,7 @@ applications:
       - gorillaOnprem
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: filestream
     features:
       - filestreamQueue
@@ -457,7 +457,7 @@ applications:
       - gorillaOnprem
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: flat-run-fields-updater
     args:
       - flat-run-fields-updater
@@ -474,11 +474,11 @@ applications:
         value: "$(KAFKA_URL)/$(KAFKA_RUNS_V2_TOPIC_NAME)?consumer_group_id=flat-run-fields-updater"
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: frontend
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     commonEnvs:
       - frontend
     env:
@@ -550,7 +550,7 @@ applications:
         value: "memory://"
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: metric-observer
     args:
       - metric-observer
@@ -567,7 +567,7 @@ applications:
         value: "$(KAFKA_URL)/$(KAFKA_RUNS_V2_TOPIC_NAME)?consumer_group_id=metric-observer"
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
   - name: parquet
     args:
       - parquet
@@ -581,7 +581,7 @@ applications:
       - gorillaOnprem
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     ports:
       - containerPort: 8080
         name: parquet
@@ -600,7 +600,7 @@ applications:
   - name: weave
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-python
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     env:
       - name: DATADOG_TRACE_ENABLED
         value: "false"
@@ -622,7 +622,7 @@ applications:
   - name: weave-trace
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - "uvicorn"
       - "src.trace_server:app"
@@ -659,7 +659,7 @@ applications:
   - name: weave-trace-worker
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - "python"
       - "-m"
@@ -674,7 +674,7 @@ applications:
   - name: weave-trace-evaluate-model-worker
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - "python"
       - "-m"
@@ -834,7 +834,7 @@ migrations:
   gorilla:
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - "migrate"
       - "--db=$(GORILLA_METADATA_STORE)"
@@ -844,10 +844,11 @@ migrations:
       - "true"
     commonEnvs:
       - gorillaMysql
+      - gorillaOnprem
   internal-signer:
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/megabinary
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - "secret-generation-job"
     env:
@@ -860,7 +861,7 @@ migrations:
   weave-trace:
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
-      tag: 0.78.0-pre-operator-v2-no-app.1
+      tag: 0.78.0-pre.1772047260
     args:
       - python
       - migrator.py

--- a/scripts/setup_kind.sh
+++ b/scripts/setup_kind.sh
@@ -3,6 +3,7 @@
 set -e
 
 CLUSTER_NAME="kind"
+DEV_PROFILE=1
 
 if ! command -v jq >/dev/null 2>&1; then
     echo "Error: jq is required but not installed. Please install jq."
@@ -16,6 +17,13 @@ if [[ -f "tilt-settings.json" ]]; then
     fi
 fi
 
+if [[ -f "tilt-settings.json" ]]; then
+    CRD_NAME=$(jq -r '.wandbCRD // empty' tilt-settings.json)
+    if [[ -n "$CRD_NAME" && "$CRD_NAME" != *dev* ]]; then
+        DEV_PROFILE=0
+    fi
+fi
+
 echo "Creating kind cluster: $CLUSTER_NAME"
 
 if kind get clusters | grep -q "^$CLUSTER_NAME$"; then
@@ -24,7 +32,13 @@ if kind get clusters | grep -q "^$CLUSTER_NAME$"; then
     exit 0
 fi
 
-cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
+if [[ "$DEV_PROFILE" -eq 1 ]]; then
+    cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+EOF
+else
+    cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -33,6 +47,7 @@ nodes:
 - role: worker
 - role: worker
 EOF
+fi
 
 echo "Kind cluster '$CLUSTER_NAME' created successfully with 3 worker nodes"
 


### PR DESCRIPTION
## Summary

- **Consolidate third-party operator installs**: Replace 7 individual `helm_repo`/`helm_resource` calls with a single `helm_resource('third-party-operators')` backed by the `deploy/operator` umbrella chart (`wandb-operator.enabled=false`), mirroring how operators are installed in production
- **Add explicit readiness gates**: `operator-crds-ready`, `vm-crds-ready`, `grafana-crds-ready`, and `vm-operator-ready` gates prevent resources from being applied before their CRDs or operator webhooks are ready — eliminating fresh-cluster race conditions
- **Tighten resource dependencies**: Fix missing deps (`RBAC` → codegen, `Operator-Certs` → cert-manager intent documented), remove redundant transitive deps with explanatory comments
- **Fix Helm umbrella chart**: Guard webhooks, certificates, and Wandb CR behind `wandb-operator.enabled` using `not (eq ... false)` to avoid Helm's `false | default true` trap
- **Kind cluster utilities**: Add `hack/scripts/kind-images-manager.sh` (scrape/pull/load subcommands for caching images across cluster recreations) and improve `scripts/setup_kind.sh` with single-node vs multi-node profile selection
- **Dependency graph docs**: Add `docs/design/wandb_v2/tilt.md` with a Mermaid graph of all Tilt resource dependencies, plus agent instructions for keeping it in sync with the Tiltfile

## Test plan

- [ ] `tilt up` from a fresh `kind` cluster reaches a healthy state without manual intervention
- [ ] Telemetry stack (`installTelemetry: true`) starts cleanly with all readiness gates passing in order
- [ ] `hack/scripts/kind-images-manager.sh scrape` + `pull` + `load` round-trip works against a running cluster
- [ ] `scripts/setup_kind.sh` creates a single-node cluster for dev CRDs and a multi-node cluster for non-dev CRDs
- [ ] Mermaid diagram in `docs/design/wandb_v2/tilt.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)