### PR TITLE
feat(chart): Set up managed Victoria telemetry stack and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 ## Description
 // TODO(user): An in-depth paragraph about your project and overview of use
 
+## Documentation
+
+- [Monitoring and Telemetry Guide](docs/monitoring.md)
+
 ## Development
 
 ### Prerequisites

--- a/deploy/operator/templates/_telemetry_helpers.tpl
+++ b/deploy/operator/templates/_telemetry_helpers.tpl
@@ -1,0 +1,53 @@
+{{- define "operator.telemetry.namespace" -}}
+{{- if .Values.telemetry.namespace -}}
+{{- .Values.telemetry.namespace -}}
+{{- else if .Values.wandb.namespace -}}
+{{- .Values.wandb.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "operator.telemetry.vmsingleName" -}}
+{{- .Values.telemetry.managed.vmsingle.name -}}
+{{- end -}}
+
+{{- define "operator.telemetry.vmagentName" -}}
+{{- .Values.telemetry.managed.vmagent.name -}}
+{{- end -}}
+
+{{- define "operator.telemetry.vlsingleName" -}}
+{{- .Values.telemetry.managed.vlsingle.name -}}
+{{- end -}}
+
+{{- define "operator.telemetry.vtsingleName" -}}
+{{- .Values.telemetry.managed.vtsingle.name -}}
+{{- end -}}
+
+{{- define "operator.telemetry.otlpGatewayName" -}}
+{{- .Values.telemetry.managed.otlpGateway.name -}}
+{{- end -}}
+
+{{- define "operator.telemetry.metricsEndpoint" -}}
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "external") -}}
+{{- .Values.telemetry.external.metricsEndpoint -}}
+{{- else -}}
+{{- printf "http://vmsingle-%s:8428/opentelemetry/v1/metrics" (include "operator.telemetry.vmsingleName" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "operator.telemetry.logsEndpoint" -}}
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "external") -}}
+{{- .Values.telemetry.external.logsEndpoint -}}
+{{- else -}}
+{{- printf "http://vlsingle-%s:9428/insert/opentelemetry/v1/logs" (include "operator.telemetry.vlsingleName" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "operator.telemetry.tracesEndpoint" -}}
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "external") -}}
+{{- .Values.telemetry.external.tracesEndpoint -}}
+{{- else -}}
+{{- printf "http://vtsingle-%s:10428/insert/opentelemetry/v1/traces" (include "operator.telemetry.vtsingleName" .) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/operator/templates/telemetry-alerting.yaml
+++ b/deploy/operator/templates/telemetry-alerting.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "managed") .Values.telemetry.alerting.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: wandb-telemetry-default-rules
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+    telemetry.wandb.com/rule-group: default
+spec:
+  groups:
+    - name: wandb-telemetry
+      interval: {{ .Values.telemetry.alerting.evaluationInterval | quote }}
+      rules:
+        - alert: WandbOperatorDown
+          expr: up{job=~".*wandb-operator.*"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: W&B operator metrics target is down
+            description: VictoriaMetrics cannot scrape the W&B operator metrics endpoint.
+        - alert: WandbNoKafkaMetrics
+          expr: absent(up{job=~".*kafka.*"})
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Kafka metrics are missing
+            description: No Kafka metrics targets were discovered for at least 10 minutes.
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAlert
+metadata:
+  name: wandb-vmalert
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  datasource:
+    url: {{ printf "http://vmsingle-%s:8428" (include "operator.telemetry.vmsingleName" .) | quote }}
+  remoteRead:
+    url: {{ printf "http://vmsingle-%s:8428" (include "operator.telemetry.vmsingleName" .) | quote }}
+  remoteWrite:
+    url: {{ printf "http://vmsingle-%s:8428/api/v1/write" (include "operator.telemetry.vmsingleName" .) | quote }}
+  evaluationInterval: {{ .Values.telemetry.alerting.evaluationInterval | quote }}
+  selectAllByDefault: false
+  ruleSelector:
+    matchLabels:
+      telemetry.wandb.com/rule-group: default
+  {{- if .Values.telemetry.alerting.notifier.enabled }}
+  notifiers:
+    - url: {{ .Values.telemetry.alerting.notifier.target | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/operator/templates/telemetry-otlp-gateway.yaml
+++ b/deploy/operator/templates/telemetry-otlp-gateway.yaml
@@ -1,0 +1,131 @@
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "managed") .Values.telemetry.managed.otlpGateway.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "operator.telemetry.otlpGatewayName" . }}-config
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:{{ .Values.telemetry.managed.otlpGateway.service.grpcPort }}
+          http:
+            endpoint: 0.0.0.0:{{ .Values.telemetry.managed.otlpGateway.service.httpPort }}
+
+    processors:
+      batch: {}
+
+    exporters:
+      otlphttp/vm:
+        endpoint: http://vmsingle-{{ include "operator.telemetry.vmsingleName" . }}:8428
+        metrics_endpoint: http://vmsingle-{{ include "operator.telemetry.vmsingleName" . }}:8428/opentelemetry/v1/metrics
+      otlphttp/vl:
+        endpoint: http://vlsingle-{{ include "operator.telemetry.vlsingleName" . }}:9428
+        logs_endpoint: http://vlsingle-{{ include "operator.telemetry.vlsingleName" . }}:9428/insert/opentelemetry/v1/logs
+      otlphttp/vt:
+        endpoint: http://vtsingle-{{ include "operator.telemetry.vtsingleName" . }}:10428
+        traces_endpoint: http://vtsingle-{{ include "operator.telemetry.vtsingleName" . }}:10428/insert/opentelemetry/v1/traces
+
+    service:
+      telemetry:
+        metrics:
+          address: 0.0.0.0:{{ .Values.telemetry.managed.otlpGateway.service.metricsPort }}
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlphttp/vm]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlphttp/vl]
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlphttp/vt]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "operator.telemetry.otlpGatewayName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+        app.kubernetes.io/component: telemetry
+        app.kubernetes.io/part-of: wandb
+    spec:
+      containers:
+        - name: otel-collector
+          image: {{ printf "%s:%s" .Values.telemetry.managed.otlpGateway.image.repository .Values.telemetry.managed.otlpGateway.image.tag | quote }}
+          imagePullPolicy: {{ .Values.telemetry.managed.otlpGateway.image.pullPolicy }}
+          args:
+            - --config=/etc/otelcol/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: {{ .Values.telemetry.managed.otlpGateway.service.grpcPort }}
+              protocol: TCP
+            - name: otlp-http
+              containerPort: {{ .Values.telemetry.managed.otlpGateway.service.httpPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.telemetry.managed.otlpGateway.service.metricsPort }}
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+          {{- with .Values.telemetry.managed.otlpGateway.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "operator.telemetry.otlpGatewayName" . }}-config
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "operator.telemetry.otlpGatewayName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+  ports:
+    - name: otlp-grpc
+      port: {{ .Values.telemetry.managed.otlpGateway.service.grpcPort }}
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: {{ .Values.telemetry.managed.otlpGateway.service.httpPort }}
+      targetPort: otlp-http
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.telemetry.managed.otlpGateway.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/deploy/operator/templates/telemetry-perses.yaml
+++ b/deploy/operator/templates/telemetry-perses.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.telemetry.enabled .Values.telemetry.perses.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-config
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: perses
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+data:
+  config.yaml: |
+    http:
+      bind: 0.0.0.0:{{ .Values.telemetry.perses.service.port }}
+    database:
+      file:
+        folder: /perses
+    security:
+      enableAuth: false
+    telemetry:
+      metricsEndpoint: {{ include "operator.telemetry.metricsEndpoint" . }}
+      logsEndpoint: {{ include "operator.telemetry.logsEndpoint" . }}
+      tracesEndpoint: {{ include "operator.telemetry.tracesEndpoint" . }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perses
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: perses
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: perses
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: perses
+        app.kubernetes.io/component: telemetry
+        app.kubernetes.io/part-of: wandb
+    spec:
+      containers:
+        - name: perses
+          image: {{ printf "%s:%s" .Values.telemetry.perses.image.repository .Values.telemetry.perses.image.tag | quote }}
+          imagePullPolicy: {{ .Values.telemetry.perses.image.pullPolicy }}
+          args:
+            - serve
+            - --config=/etc/perses/config/config.yaml
+          ports:
+            - name: http
+              containerPort: {{ .Values.telemetry.perses.service.port }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/perses/config
+            - name: data
+              mountPath: /perses
+      volumes:
+        - name: config
+          configMap:
+            name: perses-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: perses
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    app.kubernetes.io/name: perses
+  ports:
+    - name: http
+      port: {{ .Values.telemetry.perses.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/operator/templates/telemetry-scrapes.yaml
+++ b/deploy/operator/templates/telemetry-scrapes.yaml
@@ -1,0 +1,316 @@
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "managed") .Values.telemetry.scrape.enabled }}
+{{- if .Values.telemetry.scrape.kubeletCadvisor }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMNodeScrape
+metadata:
+  name: kubelet-cadvisor
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  scheme: https
+  tlsConfig:
+    insecureSkipVerify: true
+    caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  relabelConfigs:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)
+    - targetLabel: __address__
+      replacement: kubernetes.default.svc:443
+    - sourceLabels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      targetLabel: __metrics_path__
+      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+{{- end }}
+
+{{- if .Values.telemetry.scrape.operators }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: wandb-operator
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wandb-operator
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      scheme: http
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: clickhouse-operator
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app: clickhouse-operator
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: grafana-operator
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-operator
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: victoria-metrics-operator
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: victoria-metrics-operator
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+{{- if .Values.telemetry.managed.otlpGateway.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: otlp-gateway
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "operator.telemetry.otlpGatewayName" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  endpoints:
+    - port: metrics
+{{- end }}
+{{- end }}
+
+{{- if .Values.telemetry.scrape.wandbApi }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: wandb-api
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: Exists
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - path: /metrics
+      relabelConfigs:
+        - sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_name
+          regex: .*-api
+          action: keep
+        - sourceLabels:
+            - __meta_kubernetes_pod_ip
+          regex: (.+)
+          replacement: $1:8181
+          targetLabel: __address__
+          action: replace
+{{- end }}
+
+{{- if .Values.telemetry.scrape.infrastructure }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: mysql-pxc
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pxc
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: mysql-proxysql
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxysql
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: stats
+      path: /metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: mysql-innodb
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      component: mysqld
+      mysql.oracle.com/instance-type: group-member
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: kafka-brokers
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: Kafka
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: tcp-prometheus
+      path: /metrics
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: minio-tenant
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      v1.min.io/tenant: wandb-minio
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: minio-port
+      path: /minio/metrics/v3
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: redis
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      role: replication
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  podMetricsEndpoints:
+    - port: redis-exporter
+      path: /metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse-metrics
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app: clickhouse-metrics
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    clickhouse.altinity.com/chi: wandb-ch-install
+  ports:
+    - name: metrics
+      port: 9363
+      targetPort: 9363
+      protocol: TCP
+  clusterIP: None
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: clickhouse
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app: clickhouse-metrics
+  namespaceSelector:
+    matchNames:
+      - {{ include "operator.telemetry.namespace" . }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+{{- end }}
+{{- end }}

--- a/deploy/operator/templates/telemetry-ui.yaml
+++ b/deploy/operator/templates/telemetry-ui.yaml
@@ -1,0 +1,111 @@
+{{- if and .Values.telemetry.enabled .Values.telemetry.ui.grafana.enabled }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    dashboards: grafana
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  config:
+    log:
+      mode: console
+    auth:
+      disable_login_form: "true"
+    auth.anonymous:
+      enabled: "true"
+      org_role: Admin
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              env:
+                - name: GF_INSTALL_PLUGINS
+                  value: victoriametrics-metrics-datasource,victoriametrics-logs-datasource
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: victoria-metrics
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: VictoriaMetrics
+    type: victoriametrics-metrics-datasource
+    access: proxy
+    url: {{ include "operator.telemetry.metricsEndpoint" . | trimSuffix "/opentelemetry/v1/metrics" | quote }}
+    isDefault: true
+    jsonData:
+      timeInterval: 30s
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: victoria-logs
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: VictoriaLogs
+    type: victoriametrics-logs-datasource
+    access: proxy
+    url: {{ include "operator.telemetry.logsEndpoint" . | trimSuffix "/insert/opentelemetry/v1/logs" | quote }}
+    jsonData:
+      maxLines: 1000
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: victoria-traces
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: VictoriaTraces
+    type: jaeger
+    access: proxy
+    url: {{ include "operator.telemetry.tracesEndpoint" . | trimSuffix "/insert/opentelemetry/v1/traces" | quote }}
+{{- end }}
+
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "managed") .Values.telemetry.ui.vmui.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vmui
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/name: vmui
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    app.kubernetes.io/name: vmsingle
+    app.kubernetes.io/instance: {{ include "operator.telemetry.vmsingleName" . }}
+  ports:
+    - name: http
+      port: 8428
+      targetPort: 8428
+      protocol: TCP
+{{- end }}

--- a/deploy/operator/templates/telemetry-victoria-core.yaml
+++ b/deploy/operator/templates/telemetry-victoria-core.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.telemetry.enabled (eq .Values.telemetry.mode "managed") }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMSingle
+metadata:
+  name: {{ include "operator.telemetry.vmsingleName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  retentionPeriod: {{ .Values.telemetry.managed.retentionPeriod | quote }}
+  {{- with .Values.telemetry.managed.vmsingle.extraArgs }}
+  extraArgs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAgent
+metadata:
+  name: {{ include "operator.telemetry.vmagentName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selectAllByDefault: {{ .Values.telemetry.managed.vmagent.selectAllByDefault }}
+  remoteWrite:
+    - url: {{ printf "http://vmsingle-%s:8428/api/v1/write" (include "operator.telemetry.vmsingleName" .) | quote }}
+---
+apiVersion: operator.victoriametrics.com/v1
+kind: VLSingle
+metadata:
+  name: {{ include "operator.telemetry.vlsingleName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  retentionPeriod: {{ .Values.telemetry.managed.retentionPeriod | quote }}
+---
+apiVersion: operator.victoriametrics.com/v1
+kind: VTSingle
+metadata:
+  name: {{ include "operator.telemetry.vtsingleName" . }}
+  namespace: {{ include "operator.telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  retentionPeriod: {{ .Values.telemetry.managed.retentionPeriod | quote }}
+{{- end }}

--- a/deploy/operator/templates/wandb-operator-grafana-role.yaml
+++ b/deploy/operator/templates/wandb-operator-grafana-role.yaml
@@ -3,3 +3,39 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-grafana
 rules:
+  - apiGroups:
+      - grafana.integreatly.org
+    resources:
+      - grafanas
+      - grafanadatasources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - grafana.integreatly.org
+    resources:
+      - grafanas/status
+      - grafanadatasources/status
+    verbs:
+      - get
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-grafana
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-grafana
+subjects:
+  - kind: ServiceAccount
+    name: wandb-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/operator/templates/wandb-operator-minio-role.yaml
+++ b/deploy/operator/templates/wandb-operator-minio-role.yaml
@@ -21,7 +21,8 @@ rules:
       - tenants/status
     verbs:
       - get
-      -
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/operator/templates/wandb-operator-vm-role.yaml
+++ b/deploy/operator/templates/wandb-operator-vm-role.yaml
@@ -3,3 +3,49 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-vm
 rules:
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmagents
+      - vmalerts
+      - vmnodescrapes
+      - vmpodscrapes
+      - vmrules
+      - vmservicescrapes
+      - vmsingles
+      - vlsingles
+      - vtsingles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmagents/status
+      - vmalerts/status
+      - vmsingles/status
+      - vlsingles/status
+      - vtsingles/status
+    verbs:
+      - get
+      - patch
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-vm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-vm
+subjects:
+  - kind: ServiceAccount
+    name: wandb-operator
+    namespace: {{ .Release.Namespace }}

--- a/deploy/operator/values.schema.json
+++ b/deploy/operator/values.schema.json
@@ -1,0 +1,324 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["managed", "external"]
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "otel": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "protocol": {
+              "type": "string",
+              "minLength": 1
+            },
+            "serviceName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "resourceAttributes": {
+              "type": "string"
+            }
+          }
+        },
+        "external": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "metricsEndpoint": {
+              "type": "string"
+            },
+            "logsEndpoint": {
+              "type": "string"
+            },
+            "tracesEndpoint": {
+              "type": "string"
+            }
+          }
+        },
+        "managed": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "retentionPeriod": {
+              "type": "string",
+              "minLength": 1
+            },
+            "vmsingle": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "extraArgs": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "vmagent": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "selectAllByDefault": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "vlsingle": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "vtsingle": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "otlpGateway": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "image": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "repository": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "tag": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pullPolicy": {
+                      "type": "string",
+                      "enum": ["Always", "IfNotPresent", "Never"]
+                    }
+                  }
+                },
+                "service": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "grpcPort": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 65535
+                    },
+                    "httpPort": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 65535
+                    },
+                    "metricsPort": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 65535
+                    }
+                  }
+                },
+                "resources": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "scrape": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "kubeletCadvisor": {
+              "type": "boolean"
+            },
+            "operators": {
+              "type": "boolean"
+            },
+            "wandbApi": {
+              "type": "boolean"
+            },
+            "infrastructure": {
+              "type": "boolean"
+            }
+          }
+        },
+        "alerting": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "evaluationInterval": {
+              "type": "string",
+              "minLength": 1
+            },
+            "notifier": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["webhook", "email", "slack"]
+                },
+                "target": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "perses": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "image": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tag": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": ["Always", "IfNotPresent", "Never"]
+                }
+              }
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                }
+              }
+            }
+          }
+        },
+        "ui": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "grafana": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "vmui": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "mode": {
+                "const": "external"
+              }
+            },
+            "required": ["enabled", "mode"]
+          },
+          "then": {
+            "required": ["external"],
+            "properties": {
+              "external": {
+                "required": ["metricsEndpoint", "logsEndpoint", "tracesEndpoint"],
+                "properties": {
+                  "metricsEndpoint": {
+                    "minLength": 1
+                  },
+                  "logsEndpoint": {
+                    "minLength": 1
+                  },
+                  "tracesEndpoint": {
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "additionalProperties": true
+}

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -27,6 +27,38 @@ wandb-operator:
           value: ":8443"
         METRICS_SECURE:
           value: "false"
+        TELEMETRY_ENABLED:
+          value: "{{ .Values.telemetry.enabled }}"
+        TELEMETRY_MODE:
+          value: "{{ .Values.telemetry.mode }}"
+        TELEMETRY_METRICS_ENDPOINT:
+          value: "{{ .Values.telemetry.external.metricsEndpoint }}"
+        TELEMETRY_LOGS_ENDPOINT:
+          value: "{{ .Values.telemetry.external.logsEndpoint }}"
+        TELEMETRY_TRACES_ENDPOINT:
+          value: "{{ .Values.telemetry.external.tracesEndpoint }}"
+        TELEMETRY_MANAGED_NAMESPACE:
+          value: "{{ .Values.telemetry.namespace }}"
+        TELEMETRY_MANAGED_VMSINGLE_NAME:
+          value: "{{ .Values.telemetry.managed.vmsingle.name }}"
+        TELEMETRY_MANAGED_VLSINGLE_NAME:
+          value: "{{ .Values.telemetry.managed.vlsingle.name }}"
+        TELEMETRY_MANAGED_VTSINGLE_NAME:
+          value: "{{ .Values.telemetry.managed.vtsingle.name }}"
+        TELEMETRY_MANAGED_OTLP_GATEWAY_ENABLED:
+          value: "{{ .Values.telemetry.managed.otlpGateway.enabled }}"
+        TELEMETRY_MANAGED_OTLP_GATEWAY_NAME:
+          value: "{{ .Values.telemetry.managed.otlpGateway.name }}"
+        TELEMETRY_MANAGED_OTLP_GATEWAY_HTTP_PORT:
+          value: "{{ .Values.telemetry.managed.otlpGateway.service.httpPort }}"
+        TELEMETRY_OTEL_SECRET_NAME:
+          value: "{{ .Values.telemetry.otel.secretName }}"
+        TELEMETRY_OTEL_PROTOCOL:
+          value: "{{ .Values.telemetry.otel.protocol }}"
+        TELEMETRY_OTEL_SERVICE_NAME:
+          value: "{{ .Values.telemetry.otel.serviceName }}"
+        TELEMETRY_OTEL_RESOURCE_ATTRIBUTES:
+          value: "{{ .Values.telemetry.otel.resourceAttributes }}"
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -87,6 +119,32 @@ wandb-operator:
     redis: true
     vm: true
 
+  telemetry:
+    enabled: false
+    mode: managed
+    namespace: wandb
+    external:
+      metricsEndpoint: ""
+      logsEndpoint: ""
+      tracesEndpoint: ""
+    managed:
+      vmsingle:
+        name: victoria-instance
+      vlsingle:
+        name: victoria-logs
+      vtsingle:
+        name: victoria-traces
+      otlpGateway:
+        enabled: true
+        name: victoria-otlp-gateway
+        service:
+          httpPort: 4318
+    otel:
+      secretName: wandb-otel-connection
+      protocol: http/protobuf
+      serviceName: wandb-service
+      resourceAttributes: deployment.environment=dev
+
 mysql-operator:
   install: true
 
@@ -113,3 +171,69 @@ victoria-metrics-operator:
 
 grafana-operator:
   install: true
+
+telemetry:
+  enabled: false
+  mode: managed
+  namespace: ""
+  otel:
+    secretName: wandb-otel-connection
+    protocol: http/protobuf
+    serviceName: wandb-service
+    resourceAttributes: deployment.environment=dev
+  external:
+    metricsEndpoint: ""
+    logsEndpoint: ""
+    tracesEndpoint: ""
+  managed:
+    retentionPeriod: 1d
+    vmsingle:
+      name: victoria-instance
+      extraArgs:
+        opentelemetry.usePrometheusNaming: "true"
+    vmagent:
+      name: victoria-agent
+      selectAllByDefault: true
+    vlsingle:
+      name: victoria-logs
+    vtsingle:
+      name: victoria-traces
+    otlpGateway:
+      enabled: true
+      name: victoria-otlp-gateway
+      image:
+        repository: otel/opentelemetry-collector-contrib
+        tag: 0.102.1
+        pullPolicy: IfNotPresent
+      service:
+        grpcPort: 4317
+        httpPort: 4318
+        metricsPort: 8888
+      resources: {}
+  scrape:
+    enabled: true
+    kubeletCadvisor: true
+    operators: true
+    wandbApi: true
+    infrastructure: true
+  alerting:
+    enabled: false
+    evaluationInterval: 30s
+    notifier:
+      enabled: false
+      name: default
+      type: webhook
+      target: http://alertmanager-operated.monitoring.svc:9093
+  perses:
+    enabled: false
+    image:
+      repository: ghcr.io/perses/perses
+      tag: v0.52.0
+      pullPolicy: IfNotPresent
+    service:
+      port: 8080
+  ui:
+    grafana:
+      enabled: false
+    vmui:
+      enabled: false

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,152 @@
+# Monitoring and Telemetry Guide
+
+This repo now supports a consolidated telemetry stack with VictoriaMetrics in both Helm and Tilt workflows.
+
+## Modes
+
+### Managed mode
+Use this when the chart should install telemetry components in-cluster.
+
+Installed (optional/toggle-driven):
+- `VMSingle`
+- `VMAgent`
+- `VLSingle`
+- `VTSingle`
+- Scrapes (`VMNodeScrape`, `VMPodScrape`, `VMServiceScrape`)
+- Alerting (`VMRule`, `VMAlert`)
+- Optional UI (`Grafana`, `vmui`)
+- Optional `Perses`
+
+### External mode
+Use this when metrics/logs/traces should be exported to existing external endpoints.
+
+In external mode, managed VM resources are not rendered.
+
+## Helm Configuration
+
+### 1. Telemetry stack values (chart resources)
+Set these under top-level `telemetry`.
+
+Managed example:
+
+```yaml
+telemetry:
+  enabled: true
+  mode: managed
+  namespace: wandb
+  ui:
+    grafana:
+      enabled: false
+    vmui:
+      enabled: false
+  alerting:
+    enabled: true
+    notifier:
+      enabled: true
+      target: http://alertmanager-operated.monitoring.svc:9093
+```
+
+External example:
+
+```yaml
+telemetry:
+  enabled: true
+  mode: external
+  external:
+    metricsEndpoint: https://metrics.example.com/v1/metrics
+    logsEndpoint: https://logs.example.com/v1/logs
+    tracesEndpoint: https://traces.example.com/v1/traces
+```
+
+### 2. Operator runtime telemetry values (secret + env source resolution)
+Set these under `wandb-operator.telemetry`.
+
+```yaml
+wandb-operator:
+  telemetry:
+    enabled: true
+    mode: managed
+    managed:
+      vmsingleName: victoria-instance
+      vlsingleName: victoria-logs
+      vtsingleName: victoria-traces
+    otel:
+      secretName: wandb-otel-connection
+      protocol: http/protobuf
+      serviceName: wandb-service
+      resourceAttributes: deployment.environment=prod
+```
+
+For external runtime:
+
+```yaml
+wandb-operator:
+  telemetry:
+    enabled: true
+    mode: external
+    metricsEndpoint: https://metrics.example.com/v1/metrics
+    logsEndpoint: https://logs.example.com/v1/logs
+    tracesEndpoint: https://traces.example.com/v1/traces
+```
+
+## Tilt Usage
+
+Set `installTelemetry: true` in `tilt-settings.json`.
+
+Tilt now uses Helm-driven telemetry resources (no static telemetry YAML apply path), and passes telemetry runtime flags to the locally built operator manager.
+
+## Using `source.type=telemetry` in manifests
+
+You can source app env vars from the operator-managed telemetry secret:
+
+```yaml
+env:
+  - name: GORILLA_TRACER
+    sources:
+      - type: telemetry
+        field: gorillaTracer
+  - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    sources:
+      - type: telemetry
+        field: metricsEndpoint
+  - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+    sources:
+      - type: telemetry
+        field: logsEndpoint
+  - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    sources:
+      - type: telemetry
+        field: tracesEndpoint
+```
+
+Supported telemetry `field` values:
+- `metricsEndpoint`
+- `logsEndpoint`
+- `tracesEndpoint`
+- `metricsExporter`
+- `logsExporter`
+- `tracesExporter`
+- `protocol`
+- `serviceName`
+- `resourceAttributes`
+- `gorillaTracer`
+
+## Validation Checklist
+
+1. Render checks:
+   - `helm template ... --set telemetry.enabled=true --set telemetry.mode=managed`
+   - `helm template ... --set telemetry.enabled=true --set telemetry.mode=external --set telemetry.external.metricsEndpoint=... --set telemetry.external.logsEndpoint=... --set telemetry.external.tracesEndpoint=...`
+2. Secret check:
+   - `kubectl get secret wandb-otel-connection -n <wandb-namespace> -o yaml`
+3. Pod env check:
+   - `kubectl exec -n <wandb-namespace> deploy/<app> -- env | grep OTEL_`
+4. Alerting check:
+   - `kubectl get vmalert,vmrule -n <telemetry-namespace>`
+5. Optional UI check:
+   - `kubectl get grafana,grafanadatasource -n <telemetry-namespace>`
+   - `kubectl get svc vmui -n <telemetry-namespace>`
+
+## Notes
+
+- Per-infrastructure telemetry toggles in the W&B CR (`mysql/redis/kafka/minio/clickhouse.telemetry.enabled`) remain in place for exporter behavior.
+- Managed Grafana and vmui remain disabled by default.

--- a/internal/controller/v2/telemetry_chart_test.go
+++ b/internal/controller/v2/telemetry_chart_test.go
@@ -1,0 +1,112 @@
+package v2
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTelemetryChartManagedModeRendersCoreStack(t *testing.T) {
+	output := runHelmTemplate(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=managed",
+	)
+
+	mustContain(t, output, "kind: VMSingle")
+	mustContain(t, output, "kind: VMAgent")
+	mustContain(t, output, "kind: VLSingle")
+	mustContain(t, output, "kind: VTSingle")
+	mustContain(t, output, "name: victoria-otlp-gateway-config")
+	mustContain(t, output, "name: victoria-otlp-gateway")
+}
+
+func TestTelemetryChartExternalModeSkipsManagedStack(t *testing.T) {
+	output := runHelmTemplate(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=external",
+		"--set", "telemetry.external.metricsEndpoint=https://metrics.example.com/v1/metrics",
+		"--set", "telemetry.external.logsEndpoint=https://logs.example.com/v1/logs",
+		"--set", "telemetry.external.tracesEndpoint=https://traces.example.com/v1/traces",
+	)
+
+	mustNotContain(t, output, "kind: VMSingle")
+	mustNotContain(t, output, "kind: VMAgent")
+	mustNotContain(t, output, "kind: VLSingle")
+	mustNotContain(t, output, "kind: VTSingle")
+	mustNotContain(t, output, "name: victoria-otlp-gateway-config")
+	mustNotContain(t, output, "name: victoria-otlp-gateway")
+}
+
+func TestTelemetryChartUIToggles(t *testing.T) {
+	defaultOutput := runHelmTemplate(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=managed",
+	)
+	mustNotContain(t, defaultOutput, "kind: Grafana")
+	mustNotContain(t, defaultOutput, "name: vmui")
+
+	toggledOutput := runHelmTemplate(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=managed",
+		"--set", "telemetry.ui.grafana.enabled=true",
+		"--set", "telemetry.ui.vmui.enabled=true",
+	)
+	mustContain(t, toggledOutput, "kind: Grafana")
+	mustContain(t, toggledOutput, "kind: GrafanaDatasource")
+	mustContain(t, toggledOutput, "name: vmui")
+}
+
+func TestTelemetryChartExternalModeSchemaGuard(t *testing.T) {
+	_, err := runHelmTemplateWithError(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=external",
+	)
+	if err == nil {
+		t.Fatalf("expected helm template to fail when external telemetry endpoints are missing")
+	}
+}
+
+func runHelmTemplate(t *testing.T, extraArgs ...string) string {
+	t.Helper()
+	output, err := runHelmTemplateWithError(t, extraArgs...)
+	if err != nil {
+		t.Fatalf("helm template failed: %v\noutput:\n%s", err, output)
+	}
+	return output
+}
+
+func runHelmTemplateWithError(t *testing.T, extraArgs ...string) (string, error) {
+	t.Helper()
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skipf("helm binary not found: %v", err)
+		return "", nil
+	}
+
+	chartPath := filepath.Join("..", "..", "..", "deploy", "operator")
+	args := []string{"template", "telemetry-test", chartPath, "-n", "wandb-operator"}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command("helm", args...)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func mustContain(t *testing.T, output, value string) {
+	t.Helper()
+	if !strings.Contains(output, value) {
+		t.Fatalf("expected output to contain %q", value)
+	}
+}
+
+func mustNotContain(t *testing.T, output, value string) {
+	t.Helper()
+	if strings.Contains(output, value) {
+		t.Fatalf("expected output not to contain %q", value)
+	}
+}


### PR DESCRIPTION
This PR sets up a managed Victoria metrics stack via the 3rd party operator (already exists), and creates a set of operator templates to manage deployment and configuration of telemetry resources.