### PR TITLE
fix(telemetry): Fixes tests and manifest for map[string]Application

### DIFF
--- a/hack/testing-manifests/server-manifest/0.79.0/manifest.yaml
+++ b/hack/testing-manifests/server-manifest/0.79.0/manifest.yaml
@@ -493,7 +493,8 @@ commonVolumeMounts:
         type: secret
 
 applications:
-  - name: anaconda2
+  anaconda2:
+    name: anaconda2
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/anaconda2
       tag: 0.79.0
@@ -541,7 +542,8 @@ applications:
             enabled: true
             maxReplicas: 3
             minReplicas: 2
-  - name: api
+  api:
+    name: api
     commonEnvs:
       - gorillaMysql
       - gorillaBucket
@@ -619,7 +621,8 @@ applications:
             enabled: true
             maxReplicas: 3
             minReplicas: 2
-  - name: executor
+  executor:
+    name: executor
     args:
       - executor
     commonEnvs:
@@ -649,7 +652,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 1
-  - name: filemeta
+  filemeta:
+    name: filemeta
     args:
       - filemeta
     commonEnvs:
@@ -688,7 +692,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 1
-  - name: filestream
+  filestream:
+    name: filestream
     features:
       - filestreamQueue
     args:
@@ -731,7 +736,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 1
-  - name: flat-run-fields-updater
+  flat-run-fields-updater:
+    name: flat-run-fields-updater
     args:
       - flat-run-fields-updater
     commonEnvs:
@@ -777,7 +783,8 @@ applications:
             enabled: true
             maxReplicas: 5
             minReplicas: 1
-  - name: frontend
+  frontend:
+    name: frontend
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx
       tag: 0.79.0
@@ -856,7 +863,8 @@ applications:
             enabled: true
             maxReplicas: 3
             minReplicas: 2
-  - name: glue
+  glue:
+    name: glue
     args:
       - glue
     commonEnvs:
@@ -901,7 +909,8 @@ applications:
           requests:
             cpu: "2"
             memory: 6Gi
-  - name: metric-observer
+  metric-observer:
+    name: metric-observer
     args:
       - metric-observer
     commonEnvs:
@@ -947,7 +956,8 @@ applications:
             enabled: true
             maxReplicas: 4
             minReplicas: 1
-  - name: parquet
+  parquet:
+    name: parquet
     args:
       - parquet
     commonEnvs:
@@ -1005,7 +1015,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 2
-  - name: weave
+  weave:
+    name: weave
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-python
       tag: 0.79.0
@@ -1078,7 +1089,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 2
-  - name: weave-trace
+  weave-trace:
+    name: weave-trace
     commonEnvs:
       - clickhouse
       - kafka
@@ -1144,7 +1156,8 @@ applications:
             enabled: true
             maxReplicas: 3
             minReplicas: 2
-  - name: weave-trace-worker
+  weave-trace-worker:
+    name: weave-trace-worker
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
       tag: 0.79.0
@@ -1188,7 +1201,8 @@ applications:
             enabled: true
             maxReplicas: 4
             minReplicas: 1
-  - name: weave-trace-evaluate-model-worker
+  weave-trace-evaluate-model-worker:
+    name: weave-trace-evaluate-model-worker
     image:
       repository: us-docker.pkg.dev/wandb-production/public/wandb/weave-trace
       tag: 0.79.0
@@ -1232,7 +1246,8 @@ applications:
             enabled: true
             maxReplicas: 2
             minReplicas: 1
-  - name: nginx-proxy
+  nginx-proxy:
+    name: nginx-proxy
     features:
       - proxy
     image:

--- a/internal/controller/v2/telemetry_test.go
+++ b/internal/controller/v2/telemetry_test.go
@@ -327,8 +327,8 @@ func TestResolveEnvvarsServiceSourceFromManifest(t *testing.T) {
 
 	wandb := &apiv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb-dev-v2", Namespace: "default"}}
 	manifest := serverManifest.Manifest{
-		Applications: []serverManifest.Application{
-			{
+		Applications: map[string]serverManifest.Application{
+			"anaconda2": {
 				Name: "anaconda2",
 				Service: &serverManifest.ServiceSpec{
 					Ports: []corev1.ServicePort{
@@ -367,8 +367,8 @@ func TestResolveEnvvarsServiceSourcePortNameFromManifest(t *testing.T) {
 
 	wandb := &apiv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb-dev-v2", Namespace: "default"}}
 	manifest := serverManifest.Manifest{
-		Applications: []serverManifest.Application{
-			{
+		Applications: map[string]serverManifest.Application{
+			"parquet": {
 				Name: "parquet",
 				Service: &serverManifest.ServiceSpec{
 					Ports: []corev1.ServicePort{


### PR DESCRIPTION
## Summary
- Update `TestResolveEnvvarsServiceSourceFromManifest` and `TestResolveEnvvarsServiceSourcePortNameFromManifest` test fixtures to use `map[string]Application` instead of `[]Application`, matching the `Manifest.Applications` type change
- Convert 0.79.0 server manifest `applications` section from YAML array to map keyed by application name

## Test plan
- [x] `go build ./...` passes
- [x] `TestResolveEnvvarsServiceSource*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)