### PR TITLE
fix(telemetry): Update telemetry config for cleaner applies

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -200,6 +200,12 @@ third_party_operator_flags = [
     '--create-namespace',
 ]
 
+if settings.get("installTelemetry"):
+    third_party_operator_flags += [
+        '--set=victoria-metrics-operator.enabled=true',
+        '--set=grafana-operator.enabled=true',
+    ]
+
 helm_resource(
     'ThirdParty-Operators',
     chart='./deploy/operator',
@@ -374,7 +380,8 @@ if settings.get("installTelemetry"):
         'crd/vmpodscrapes.operator.victoriametrics.com ' +
         'crd/vmnodescrapes.operator.victoriametrics.com ' +
         'crd/grafanas.grafana.integreatly.org ' +
-        'crd/grafanadatasources.grafana.integreatly.org' +
+        'crd/grafanadatasources.grafana.integreatly.org ' +
+        'crd/grafanadashboards.grafana.integreatly.org' +
         ' && kubectl wait --for=condition=available --timeout=180s -n wandb-operator ' +
         'deploy/third-party-operators-victoria-metrics-operator ' +
         'deploy/third-party-operators-grafana-operator',
@@ -387,7 +394,7 @@ if settings.get("installTelemetry"):
         release_name='telemetry-stack',
         namespace='wandb-operator',
         flags=[
-            '--set=enabled=true',
+            '--set=mode=full',
             '--set=namespace=default',
             '--create-namespace',
         ],

--- a/Tiltfile
+++ b/Tiltfile
@@ -196,7 +196,7 @@ local_resource(
 
 third_party_operator_flags = [
     '--set=wandb-operator.enabled=false',
-    '--set=telemetry.enabled=false',
+    '--set=telemetry.mode=off',
     '--create-namespace',
 ]
 

--- a/deploy/operator/Chart.lock
+++ b/deploy/operator/Chart.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: telemetry
   repository: file://../telemetry
   version: 0.1.0
-digest: sha256:48dc64abd091854d356dfd3181eef80c3467dc71a81e08a42b94ce91c2720ef0
-generated: "2026-03-24T09:04:26.823719-07:00"
+digest: sha256:9e8fefe7571cbdabfa706781ecde75570791fd8e153eb4f42220e99d99f7d91a
+generated: "2026-04-09T09:25:17.078486-07:00"

--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -47,4 +47,3 @@ dependencies:
   - name: telemetry
     version: 0.1.0
     repository: file://../telemetry
-    condition: telemetry.enabled

--- a/deploy/operator/profiles/telemetry-forward.yaml
+++ b/deploy/operator/profiles/telemetry-forward.yaml
@@ -1,0 +1,8 @@
+telemetry:
+  mode: "forward"
+
+victoria-metrics-operator:
+  enabled: true
+
+grafana-operator:
+  enabled: false

--- a/deploy/operator/profiles/telemetry-full.yaml
+++ b/deploy/operator/profiles/telemetry-full.yaml
@@ -1,0 +1,8 @@
+telemetry:
+  mode: "full"
+
+victoria-metrics-operator:
+  enabled: true
+
+grafana-operator:
+  enabled: true

--- a/deploy/operator/profiles/telemetry-off.yaml
+++ b/deploy/operator/profiles/telemetry-off.yaml
@@ -1,0 +1,8 @@
+telemetry:
+  mode: "off"
+
+victoria-metrics-operator:
+  enabled: false
+
+grafana-operator:
+  enabled: false

--- a/deploy/operator/templates/telemetry-config.yaml
+++ b/deploy/operator/templates/telemetry-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-telemetry-config
+  namespace: {{ .Release.Namespace }}
+data:
+  TELEMETRY_ENABLED: {{ ne (default "off" .Values.telemetry.mode) "off" | quote }}
+  TELEMETRY_MANAGED_NAMESPACE: {{ .Values.telemetry.namespace | quote }}
+  TELEMETRY_OTEL_SECRET_NAME: {{ .Values.telemetry.otel.secretName | quote }}
+  TELEMETRY_OTEL_PROTOCOL: {{ .Values.telemetry.otel.protocol | quote }}
+  TELEMETRY_OTEL_SERVICE_NAME: {{ .Values.telemetry.otel.serviceName | quote }}
+  TELEMETRY_OTEL_RESOURCE_ATTRIBUTES: {{ .Values.telemetry.otel.resourceAttributes | quote }}

--- a/deploy/operator/templates/telemetry-validation.yaml
+++ b/deploy/operator/templates/telemetry-validation.yaml
@@ -1,0 +1,18 @@
+{{- $mode := default "off" .Values.telemetry.mode -}}
+{{- $stackEnabled := or (eq $mode "forward") (eq $mode "full") -}}
+{{- $uiEnabled := eq $mode "full" -}}
+{{- if and (eq $mode "off") (index .Values "victoria-metrics-operator" "enabled") -}}
+{{- fail "telemetry.mode=off requires victoria-metrics-operator.enabled=false" -}}
+{{- end -}}
+{{- if and (eq $mode "off") (index .Values "grafana-operator" "enabled") -}}
+{{- fail "telemetry.mode=off requires grafana-operator.enabled=false" -}}
+{{- end -}}
+{{- if and $stackEnabled (not (index .Values "victoria-metrics-operator" "enabled")) -}}
+{{- fail "telemetry.mode=forward/full requires victoria-metrics-operator.enabled=true" -}}
+{{- end -}}
+{{- if and $uiEnabled (not (index .Values "grafana-operator" "enabled")) -}}
+{{- fail "telemetry.mode=full requires grafana-operator.enabled=true" -}}
+{{- end -}}
+{{- if and (eq $mode "forward") (eq (default "" .Values.telemetry.forwarding.otlp.endpoint) "") -}}
+{{- fail "telemetry.mode=forward requires telemetry.forwarding.otlp.endpoint" -}}
+{{- end -}}

--- a/deploy/operator/templates/telemetry-validation.yaml
+++ b/deploy/operator/templates/telemetry-validation.yaml
@@ -1,16 +1,21 @@
 {{- $mode := default "off" .Values.telemetry.mode -}}
 {{- $stackEnabled := or (eq $mode "forward") (eq $mode "full") -}}
 {{- $uiEnabled := eq $mode "full" -}}
-{{- if and (eq $mode "off") (index .Values "victoria-metrics-operator" "enabled") -}}
+{{- $operatorEnabled := true -}}
+{{- $operatorValues := index .Values "wandb-operator" -}}
+{{- if and $operatorValues (hasKey $operatorValues "enabled") -}}
+{{- $operatorEnabled = index $operatorValues "enabled" -}}
+{{- end -}}
+{{- if and $operatorEnabled (eq $mode "off") (index .Values "victoria-metrics-operator" "enabled") -}}
 {{- fail "telemetry.mode=off requires victoria-metrics-operator.enabled=false" -}}
 {{- end -}}
-{{- if and (eq $mode "off") (index .Values "grafana-operator" "enabled") -}}
+{{- if and $operatorEnabled (eq $mode "off") (index .Values "grafana-operator" "enabled") -}}
 {{- fail "telemetry.mode=off requires grafana-operator.enabled=false" -}}
 {{- end -}}
-{{- if and $stackEnabled (not (index .Values "victoria-metrics-operator" "enabled")) -}}
+{{- if and $operatorEnabled $stackEnabled (not (index .Values "victoria-metrics-operator" "enabled")) -}}
 {{- fail "telemetry.mode=forward/full requires victoria-metrics-operator.enabled=true" -}}
 {{- end -}}
-{{- if and $uiEnabled (not (index .Values "grafana-operator" "enabled")) -}}
+{{- if and $operatorEnabled $uiEnabled (not (index .Values "grafana-operator" "enabled")) -}}
 {{- fail "telemetry.mode=full requires grafana-operator.enabled=true" -}}
 {{- end -}}
 {{- if and (eq $mode "forward") (eq (default "" .Values.telemetry.forwarding.otlp.endpoint) "") -}}

--- a/deploy/operator/templates/wandb-operator-grafana-role.yaml
+++ b/deploy/operator/templates/wandb-operator-grafana-role.yaml
@@ -1,3 +1,4 @@
+{{- if eq (default "off" .Values.telemetry.mode) "full" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,6 +8,7 @@ rules:
       - grafana.integreatly.org
     resources:
       - grafanas
+      - grafanadashboards
       - grafanadatasources
     verbs:
       - create
@@ -20,6 +22,7 @@ rules:
       - grafana.integreatly.org
     resources:
       - grafanas/status
+      - grafanadashboards/status
       - grafanadatasources/status
     verbs:
       - get
@@ -39,3 +42,4 @@ subjects:
   - kind: ServiceAccount
     name: wandb-operator
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/operator/templates/wandb-operator-vm-role.yaml
+++ b/deploy/operator/templates/wandb-operator-vm-role.yaml
@@ -1,3 +1,4 @@
+{{- if ne (default "off" .Values.telemetry.mode) "off" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -49,3 +50,4 @@ subjects:
   - kind: ServiceAccount
     name: wandb-operator
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/operator/values.schema.json
+++ b/deploy/operator/values.schema.json
@@ -6,11 +6,64 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean"
+        "mode": {
+          "type": "string",
+          "enum": ["off", "forward", "full"]
         },
         "namespace": {
           "type": "string"
+        },
+        "otel": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "secretName": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "serviceName": {
+              "type": "string"
+            },
+            "resourceAttributes": {
+              "type": "string"
+            }
+          }
+        },
+        "forwarding": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "otlp": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "endpoint": {
+                  "type": "string"
+                },
+                "protocol": {
+                  "type": "string",
+                  "enum": ["http/protobuf", "grpc"]
+                },
+                "headers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "tls": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "insecure": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "retentionPeriod": {
           "type": "string",
@@ -70,14 +123,6 @@
               }
             }
           }
-        },
-        "victoria-metrics-operator": {
-          "type": "object",
-          "additionalProperties": true
-        },
-        "grafana-operator": {
-          "type": "object",
-          "additionalProperties": true
         },
         "global": {
           "type": "object",

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -28,17 +28,35 @@ wandb-operator:
         METRICS_SECURE:
           value: "false"
         TELEMETRY_ENABLED:
-          value: "{{ .Values.telemetry.enabled }}"
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_ENABLED
         TELEMETRY_MANAGED_NAMESPACE:
-          value: "{{ .Values.telemetry.namespace }}"
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_MANAGED_NAMESPACE
         TELEMETRY_OTEL_SECRET_NAME:
-          value: '{{ (index .Values "wandb-operator").telemetry.otel.secretName }}'
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_OTEL_SECRET_NAME
         TELEMETRY_OTEL_PROTOCOL:
-          value: '{{ (index .Values "wandb-operator").telemetry.otel.protocol }}'
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_OTEL_PROTOCOL
         TELEMETRY_OTEL_SERVICE_NAME:
-          value: '{{ (index .Values "wandb-operator").telemetry.otel.serviceName }}'
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_OTEL_SERVICE_NAME
         TELEMETRY_OTEL_RESOURCE_ATTRIBUTES:
-          value: '{{ (index .Values "wandb-operator").telemetry.otel.resourceAttributes }}'
+          valueFrom:
+            configMapKeyRef:
+              name: '{{ .Release.Name }}-telemetry-config'
+              key: TELEMETRY_OTEL_RESOURCE_ATTRIBUTES
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -99,13 +117,6 @@ wandb-operator:
     redis: true
     vm: true
 
-  telemetry:
-    otel:
-      secretName: wandb-otel-connection
-      protocol: http/protobuf
-      serviceName: wandb-service
-      resourceAttributes: deployment.environment=dev
-
 mysql-operator:
   install: true
 
@@ -128,14 +139,33 @@ altinity-clickhouse-operator:
           namespaces: [".*"]
 
 victoria-metrics-operator:
-  enabled: true
+  # Helm dependency conditions are boolean-only, so full/forward installs
+  # must opt into this dependency explicitly or via a preset values file.
+  enabled: false
 
 grafana-operator:
-  enabled: true
+  # Helm dependency conditions are boolean-only, so full installs
+  # must opt into this dependency explicitly or via a preset values file.
+  enabled: false
 
 telemetry:
-  enabled: false
-  namespace: ""
+  # off: disable telemetry collection
+  # full: run the in-cluster Victoria stack and local Grafana
+  # forward: run the in-cluster Victoria stack and forward OTLP data externally
+  mode: "off"
+  namespace: wandb
+  otel:
+    secretName: wandb-otel-connection
+    protocol: http/protobuf
+    serviceName: wandb-service
+    resourceAttributes: ""
+  forwarding:
+    otlp:
+      endpoint: ""
+      protocol: http/protobuf
+      headers: {}
+      tls:
+        insecure: false
   retentionPeriod: 1d
   scrape:
     enabled: true

--- a/deploy/telemetry/templates/_helpers.tpl
+++ b/deploy/telemetry/templates/_helpers.tpl
@@ -8,6 +8,24 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "telemetry.stackEnabled" -}}
+{{- $mode := default "off" .Values.mode -}}
+{{- if ne $mode "off" -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "telemetry.uiEnabled" -}}
+{{- $mode := default "off" .Values.mode -}}
+{{- if eq $mode "full" -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "telemetry.forwardingEnabled" -}}
+{{- if and (eq (default "off" .Values.mode) "forward") .Values.forwarding.otlp.endpoint -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "telemetry.forwardingExporterName" -}}
+{{- if eq (default "http/protobuf" .Values.forwarding.otlp.protocol) "grpc" -}}otlp/external{{- else -}}otlphttp/external{{- end -}}
+{{- end -}}
+
 {{- define "telemetry.vmsingleName" -}}
 victoria-instance
 {{- end -}}

--- a/deploy/telemetry/templates/telemetry-alerting.yaml
+++ b/deploy/telemetry/templates/telemetry-alerting.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.enabled .Values.alerting.enabled }}
+{{- if and (eq (include "telemetry.stackEnabled" .) "true") .Values.alerting.enabled }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule

--- a/deploy/telemetry/templates/telemetry-otlp-gateway.yaml
+++ b/deploy/telemetry/templates/telemetry-otlp-gateway.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.enabled }}
+{{- if eq (include "telemetry.stackEnabled" .) "true" }}
+{{- $forwardingEnabled := eq (include "telemetry.forwardingEnabled" .) "true" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -32,6 +33,25 @@ data:
       otlphttp/vt:
         endpoint: http://vtsingle-{{ include "telemetry.vtsingleName" . }}:10428
         traces_endpoint: http://vtsingle-{{ include "telemetry.vtsingleName" . }}:10428/insert/opentelemetry/v1/traces
+{{ if $forwardingEnabled }}
+{{ if eq (default "http/protobuf" .Values.forwarding.otlp.protocol) "grpc" }}
+      otlp/external:
+        endpoint: {{ .Values.forwarding.otlp.endpoint | quote }}
+        tls:
+          insecure: {{ .Values.forwarding.otlp.tls.insecure }}
+{{ with .Values.forwarding.otlp.headers }}
+        headers:
+{{ toYaml . | nindent 10 }}
+{{ end }}
+{{ else }}
+      otlphttp/external:
+        endpoint: {{ .Values.forwarding.otlp.endpoint | quote }}
+{{ with .Values.forwarding.otlp.headers }}
+        headers:
+{{ toYaml . | nindent 10 }}
+{{ end }}
+{{ end }}
+{{ end }}
 
     service:
       telemetry:
@@ -41,15 +61,15 @@ data:
         metrics:
           receivers: [otlp]
           processors: [batch]
-          exporters: [otlphttp/vm]
+          exporters: [otlphttp/vm{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
         logs:
           receivers: [otlp]
           processors: [batch]
-          exporters: [otlphttp/vl]
+          exporters: [otlphttp/vl{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [otlphttp/vt]
+          exporters: [otlphttp/vt{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/telemetry/templates/telemetry-scrapes.yaml
+++ b/deploy/telemetry/templates/telemetry-scrapes.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.enabled .Values.scrape.enabled }}
+{{- if and (eq (include "telemetry.stackEnabled" .) "true") .Values.scrape.enabled }}
 {{- if .Values.scrape.kubeletCadvisor }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/deploy/telemetry/templates/telemetry-ui.yaml
+++ b/deploy/telemetry/templates/telemetry-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if eq (include "telemetry.uiEnabled" .) "true" }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana

--- a/deploy/telemetry/templates/telemetry-victoria-core.yaml
+++ b/deploy/telemetry/templates/telemetry-victoria-core.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if eq (include "telemetry.stackEnabled" .) "true" }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle

--- a/deploy/telemetry/templates/validation.yaml
+++ b/deploy/telemetry/templates/validation.yaml
@@ -1,0 +1,4 @@
+{{- $mode := default "off" .Values.mode -}}
+{{- if and (eq $mode "forward") (eq (default "" .Values.forwarding.otlp.endpoint) "") -}}
+{{- fail "mode=forward requires forwarding.otlp.endpoint" -}}
+{{- end -}}

--- a/deploy/telemetry/values.schema.json
+++ b/deploy/telemetry/values.schema.json
@@ -3,11 +3,46 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "enabled": {
-      "type": "boolean"
+    "mode": {
+      "type": "string",
+      "enum": ["off", "forward", "full"]
     },
     "namespace": {
       "type": "string"
+    },
+    "forwarding": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "otlp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string",
+              "enum": ["http/protobuf", "grpc"]
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "insecure": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "retentionPeriod": {
       "type": "string",

--- a/deploy/telemetry/values.yaml
+++ b/deploy/telemetry/values.yaml
@@ -1,5 +1,12 @@
-enabled: false
+mode: "off"
 namespace: ""
+forwarding:
+  otlp:
+    endpoint: ""
+    protocol: http/protobuf
+    headers: {}
+    tls:
+      insecure: false
 retentionPeriod: 1d
 scrape:
   enabled: true

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -74,7 +74,11 @@ telemetry:
 
 Set `"installTelemetry": True` in `tilt-settings.star`.
 
-Tilt installs the telemetry stack through Helm and exposes endpoints for:
+Tilt treats `installTelemetry=True` as the local `full` mode. It installs the
+VictoriaMetrics and Grafana operators, then installs the standalone telemetry
+chart with `mode=full`.
+
+Tilt exposes endpoints for:
 - Grafana
 - VictoriaMetrics
 - VictoriaLogs

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,20 +1,25 @@
 # Monitoring and Telemetry Guide
 
-This repo now ships one managed telemetry stack for W&B.
+This repo now ships a configurable telemetry stack for W&B.
 
 ## Behavior
 
-- `telemetry.enabled: false`  
+- `telemetry.mode: off`  
   No telemetry stack resources are rendered and the operator does not wire OTEL endpoints.
 
-- `telemetry.enabled: true`  
-  The managed Victoria stack is installed and the operator writes OTEL connection settings for apps.
+- `telemetry.mode: forward`  
+  The Victoria stack is installed, workloads send OTEL data to the in-cluster gateway, and that gateway forwards OTLP data to a customer-managed endpoint.
 
-Installed resources in managed mode:
+- `telemetry.mode: full`  
+  The Victoria stack is installed and exposed through in-cluster Grafana dashboards and datasources.
+
+Installed resources in `forward` and `full` modes:
 - `VMSingle`, `VMAgent`, `VLSingle`, `VTSingle`
 - OTLP gateway collector (`victoria-otlp-gateway`)
 - Scrapes (`VMNodeScrape`, `VMPodScrape`, `VMServiceScrape`) when `telemetry.scrape.enabled=true`
 - Alerting (`VMRule`, `VMAlert`) when `telemetry.alerting.enabled=true`
+
+Installed resources only in `full` mode:
 - Grafana + Victoria datasources
 
 Not installed:
@@ -23,37 +28,46 @@ Not installed:
 
 ## Helm Values
 
-For the full operator install, set these under top-level `telemetry`:
+For the operator chart, set these under top-level `telemetry`:
 
 ```yaml
 telemetry:
-  enabled: true
+  mode: forward
   namespace: wandb
-  retentionPeriod: 1d
-  scrape:
-    enabled: true
-  alerting:
-    enabled: false
+  otel:
+    secretName: wandb-otel-connection
+    protocol: http/protobuf
+    serviceName: wandb-service
+    resourceAttributes: deployment.environment=prod
+  forwarding:
+    otlp:
+      endpoint: https://otel.example.com
+      protocol: http/protobuf
+      headers:
+        Authorization: Bearer <token>
 ```
 
 Notes:
 - Retention defaults to `1d`.
-- There is no customer-facing external endpoint mode in this phase.
-- `helm install wandb-operator ./deploy/operator --set telemetry.enabled=true` installs the operator plus the managed telemetry stack.
-- `helm install telemetry ./deploy/telemetry --set enabled=true --set namespace=<ns>` installs just the telemetry resources and expects the VictoriaMetrics/Grafana operators and CRDs to already exist.
+- `telemetry.mode=forward` requires `telemetry.forwarding.otlp.endpoint`.
+- The telemetry mode controls the stack behavior, but Helm still needs dependency booleans for the VictoriaMetrics and Grafana operator subcharts.
+- Use the preset files in `deploy/operator/profiles/` to avoid remembering those extra flags and to switch modes cleanly on an existing release.
+- `helm upgrade --install wandb-operator ./deploy/operator --reset-values -f ./deploy/operator/profiles/telemetry-full.yaml` installs the operator plus the full local telemetry stack.
+- `helm upgrade --install wandb-operator ./deploy/operator --reset-values -f ./deploy/operator/profiles/telemetry-off.yaml` disables the telemetry stack and its dependent operators.
+- `helm install telemetry ./deploy/telemetry --set mode=full --set namespace=<ns>` installs just the telemetry resources and expects the VictoriaMetrics/Grafana operators and CRDs to already exist.
+- When rendering YAML manually, use `helm template <release> ./deploy/operator --include-crds ...` so the VictoriaMetrics and Grafana CRDs are present before apply.
 
 ## Operator Runtime Values
 
-Set OTEL secret defaults under `wandb-operator.telemetry`:
+Set OTEL secret defaults under `telemetry.otel`:
 
 ```yaml
-wandb-operator:
-  telemetry:
-    otel:
-      secretName: wandb-otel-connection
-      protocol: http/protobuf
-      serviceName: wandb-service
-      resourceAttributes: deployment.environment=prod
+telemetry:
+  otel:
+    secretName: wandb-otel-connection
+    protocol: http/protobuf
+    serviceName: wandb-service
+    resourceAttributes: deployment.environment=prod
 ```
 
 ## Tilt Usage
@@ -93,8 +107,8 @@ env:
 ## Validation Checklist
 
 1. Render stack:
-   - `helm template ./deploy/operator --set telemetry.enabled=true`
-   - or `helm template ./deploy/telemetry --set enabled=true --set namespace=<telemetry-namespace>`
+   - `helm template wandb-operator ./deploy/operator --include-crds -f ./deploy/operator/profiles/telemetry-full.yaml`
+   - or `helm template ./deploy/telemetry --set mode=full --set namespace=<telemetry-namespace>`
 2. Verify Grafana resources:
    - `kubectl get grafana,grafanadatasource -n <telemetry-namespace>`
 3. Verify telemetry secret:

--- a/internal/controller/v2/reconcile_v2.go
+++ b/internal/controller/v2/reconcile_v2.go
@@ -354,7 +354,7 @@ func Reconcile(
 		return ctrl.Result{RequeueAfter: defaultRequeueDuration}, nil
 	}
 
-	res, err = ReconcileWandbManifest(ctx, client, wandb, manifest)
+	res, err = ReconcileWandbManifest(ctx, client, wandb, manifest, telemetryConfig)
 	// send up the manifest error for now
 	if err != nil {
 		return res, err
@@ -379,7 +379,13 @@ func consolidateResults(results []ctrl.Result) ctrl.Result {
 	}
 }
 
-func ReconcileWandbManifest(ctx context.Context, client ctrlClient.Client, wandb *apiv2.WeightsAndBiases, manifest serverManifest.Manifest) (ctrl.Result, error) {
+func ReconcileWandbManifest(
+	ctx context.Context,
+	client ctrlClient.Client,
+	wandb *apiv2.WeightsAndBiases,
+	manifest serverManifest.Manifest,
+	telemetryConfig TelemetryRuntimeConfig,
+) (ctrl.Result, error) {
 	// Reconcile Wandb Manifest
 	logger := ctrl.LoggerFrom(ctx).WithName("reconcileWandbManifest")
 	logger.Info("Reconciling Wandb Manifest", "name", wandb.Name)
@@ -463,7 +469,7 @@ func ReconcileWandbManifest(ctx context.Context, client ctrlClient.Client, wandb
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	result, err = reconcileApplications(ctx, client, wandb, manifest)
+	result, err = reconcileApplications(ctx, client, wandb, manifest, telemetryConfig)
 	if err != nil {
 		return result, err
 	}
@@ -478,7 +484,13 @@ func ReconcileWandbManifest(ctx context.Context, client ctrlClient.Client, wandb
 	return ctrl.Result{}, nil
 }
 
-func reconcileApplications(ctx context.Context, client ctrlClient.Client, wandb *apiv2.WeightsAndBiases, manifest serverManifest.Manifest) (ctrl.Result, error) {
+func reconcileApplications(
+	ctx context.Context,
+	client ctrlClient.Client,
+	wandb *apiv2.WeightsAndBiases,
+	manifest serverManifest.Manifest,
+	telemetryConfig TelemetryRuntimeConfig,
+) (ctrl.Result, error) {
 	logger := logx.GetSlog(ctx)
 	logger.Info("Reconciling applications")
 	serviceAccountName := wandb.Spec.Wandb.ServiceAccount.ServiceAccountName
@@ -513,7 +525,7 @@ func reconcileApplications(ctx context.Context, client ctrlClient.Client, wandb 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		envVars, err = injectManagedWorkloadTelemetryEnvvars(ctx, client, wandb, manifest, app, envVars)
+		envVars, err = injectManagedWorkloadTelemetryEnvvars(ctx, client, wandb, manifest, app, envVars, telemetryConfig.Enabled)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1169,8 +1181,9 @@ func injectManagedWorkloadTelemetryEnvvars(
 	manifest serverManifest.Manifest,
 	app serverManifest.Application,
 	envVars []corev1.EnvVar,
+	telemetryEnabled bool,
 ) ([]corev1.EnvVar, error) {
-	if !shouldInjectManagedWorkloadTelemetry(app.Name) {
+	if !telemetryEnabled || !shouldInjectManagedWorkloadTelemetry(app.Name) {
 		return envVars, nil
 	}
 

--- a/internal/controller/v2/telemetry_chart_test.go
+++ b/internal/controller/v2/telemetry_chart_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 )
 
-func TestTelemetryChartManagedModeRendersCoreStack(t *testing.T) {
+func TestTelemetryChartFullModeRendersCoreStack(t *testing.T) {
 	output := runHelmTemplate(t,
 		"--set", "wandb-operator.enabled=false",
-		"--set", "telemetry.enabled=true",
+		"--set", "telemetry.mode=full",
+		"--set", "victoria-metrics-operator.enabled=true",
+		"--set", "grafana-operator.enabled=true",
 	)
 
 	mustContain(t, output, "kind: VMSingle")
@@ -37,10 +39,28 @@ func TestTelemetryChartManagedModeRendersCoreStack(t *testing.T) {
 	mustContain(t, output, "retentionPeriod: \"1d\"")
 }
 
-func TestTelemetryChartDisabledSkipsManagedStack(t *testing.T) {
+func TestTelemetryChartForwardModeSkipsGrafanaButAddsForwarding(t *testing.T) {
 	output := runHelmTemplate(t,
 		"--set", "wandb-operator.enabled=false",
-		"--set", "telemetry.enabled=false",
+		"--set", "telemetry.mode=forward",
+		"--set", "telemetry.forwarding.otlp.endpoint=https://otel.example.com",
+		"--set", "victoria-metrics-operator.enabled=true",
+	)
+
+	mustContain(t, output, "kind: VMSingle")
+	mustContain(t, output, "kind: VMAgent")
+	mustContain(t, output, "kind: VLSingle")
+	mustContain(t, output, "kind: VTSingle")
+	mustContain(t, output, "name: victoria-otlp-gateway-config")
+	mustContain(t, output, "name: victoria-otlp-gateway")
+	mustContain(t, output, "endpoint: \"https://otel.example.com\"")
+	mustNotContain(t, output, "kind: Grafana")
+}
+
+func TestTelemetryChartOffModeSkipsManagedStack(t *testing.T) {
+	output := runHelmTemplate(t,
+		"--set", "wandb-operator.enabled=false",
+		"--set", "telemetry.mode=off",
 	)
 
 	mustNotContain(t, output, "kind: VMSingle")
@@ -52,9 +72,9 @@ func TestTelemetryChartDisabledSkipsManagedStack(t *testing.T) {
 	mustNotContain(t, output, "kind: Grafana")
 }
 
-func TestStandaloneTelemetryChartManagedModeRendersCoreStack(t *testing.T) {
+func TestStandaloneTelemetryChartFullModeRendersCoreStack(t *testing.T) {
 	output := runHelmTemplateForChart(t, filepath.Join("..", "..", "..", "deploy", "telemetry"),
-		"--set", "enabled=true",
+		"--set", "mode=full",
 		"--set", "namespace=wandb",
 	)
 

--- a/internal/controller/v2/telemetry_test.go
+++ b/internal/controller/v2/telemetry_test.go
@@ -480,6 +480,7 @@ func TestInjectManagedWorkloadTelemetryEnvvarsCoverage(t *testing.T) {
 				manifest,
 				serverManifest.Application{Name: appName},
 				nil,
+				true,
 			)
 			if err != nil {
 				t.Fatalf("injectManagedWorkloadTelemetryEnvvars returned error: %v", err)
@@ -512,6 +513,7 @@ func TestInjectManagedWorkloadTelemetryEnvvarsCoverage(t *testing.T) {
 			manifest,
 			serverManifest.Application{Name: "anaconda2"},
 			nil,
+			true,
 		)
 		if err != nil {
 			t.Fatalf("injectManagedWorkloadTelemetryEnvvars returned error: %v", err)
@@ -520,6 +522,31 @@ func TestInjectManagedWorkloadTelemetryEnvvarsCoverage(t *testing.T) {
 			t.Fatalf("expected no managed telemetry envs for ineligible workload, got %#v", envVars)
 		}
 	})
+}
+
+func TestInjectManagedWorkloadTelemetryEnvvarsDisabledSkipsInjection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding corev1 to scheme: %v", err)
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	wandb := &apiv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb-dev-v2", Namespace: "default"}}
+
+	envVars, err := injectManagedWorkloadTelemetryEnvvars(
+		context.Background(),
+		client,
+		wandb,
+		serverManifest.Manifest{},
+		serverManifest.Application{Name: "api"},
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("injectManagedWorkloadTelemetryEnvvars returned error: %v", err)
+	}
+	if len(envVars) != 0 {
+		t.Fatalf("expected no managed telemetry envs when telemetry is disabled, got %#v", envVars)
+	}
 }
 
 func mustFindEnvVar(t *testing.T, envs []corev1.EnvVar, name string) corev1.EnvVar {

--- a/internal/controller/weightsandbiases_controller_networking_test.go
+++ b/internal/controller/weightsandbiases_controller_networking_test.go
@@ -287,7 +287,7 @@ func reconcileNetworkingManifest(ctx context.Context, wandb *apiv2.WeightsAndBia
 	wandbManifest, err := manifest.GetServerManifest(ctx, wandb.Spec.Wandb.ManifestRepository, wandb.Spec.Wandb.Version)
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+	_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/internal/controller/weightsandbiases_controller_test.go
+++ b/internal/controller/weightsandbiases_controller_test.go
@@ -190,7 +190,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			By("Checking if Applications were NOT created yet (migrations not complete)")
 			wandbManifest, err := manifest.GetServerManifest(ctx, wandb.Spec.Wandb.ManifestRepository, wandb.Spec.Wandb.Version)
 			Expect(err).Should(Succeed())
-			_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 
 			By("Checking if the MySQL init job was created")
@@ -284,7 +284,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			By("Checking if Applications were NOT created yet (migrations not complete)")
 			wandbManifest, err := manifest.GetServerManifest(ctx, wandb.Spec.Wandb.ManifestRepository, wandb.Spec.Wandb.Version)
 			Expect(err).Should(Succeed())
-			ctrlResult, err := v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			ctrlResult, err := v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 			Expect(ctrlResult.RequeueAfter).Should(BeNumerically(">", 0))
 
@@ -302,7 +302,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			Expect(k8sClient.Status().Update(ctx, wandb)).Should(Succeed())
 
 			// For now test by calling ReconcileWandbManifest directly, but this will get refactored into the reconciler later
-			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 			Expect(ctrlResult.RequeueAfter).Should(BeZero())
 
@@ -382,7 +382,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			wandb.Status.ClickHouseStatus.Connection.URL = v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: WandbName}, Key: "test"}
 			Expect(k8sClient.Status().Update(ctx, wandb)).Should(Succeed())
 
-			ctrlResult, err := v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			ctrlResult, err := v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 			Expect(ctrlResult.RequeueAfter).Should(BeNumerically(">", 0), "Expected requeue when migration is running")
 
@@ -392,7 +392,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			wandb.Status.Wandb.Migration.Reason = "Failed"
 			Expect(k8sClient.Status().Update(ctx, wandb)).Should(Succeed())
 
-			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 			Expect(ctrlResult.RequeueAfter).Should(BeNumerically(">", 0), "Expected requeue when migration failed")
 
@@ -404,7 +404,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 			wandb.Status.Wandb.MySQLInit.Succeeded = true
 			Expect(k8sClient.Status().Update(ctx, wandb)).Should(Succeed())
 
-			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			ctrlResult, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 			Expect(ctrlResult.RequeueAfter).Should(BeZero(), "Expected no requeue when migration is complete")
 
@@ -471,7 +471,7 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 
 			// This call to ReconcileWandbManifest should trigger runMigrations,
 			// which sees version mismatch and starts migrations.
-			_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest)
+			_, err = v2.ReconcileWandbManifest(ctx, k8sClient, wandb, wandbManifest, v2.DefaultTelemetryRuntimeConfig())
 			Expect(err).Should(Succeed())
 
 			By("Verifying migration status was reset for the new version")


### PR DESCRIPTION

- Added explicit telemetry mode selection to the operator and telemetry Helm charts
- Removed the duplicated telemetry config paths
- Added chart validation so invalid mode/operator combinations fail early
- Kept VictoriaMetrics/VictoriaTraces as the in-cluster backend for `forward`, while forwarding OTLP to an external endpoint
- Added the missing Grafana RBAC/resource mappings for telemetry CRDs
- Moved operator telemetry runtime settings into a rendered ConfigMap
- Updated the controller so managed workload telemetry env vars are only injected when telemetry is enabled
- Added preset values files for local Helm testing of `off`, `forward`, and `full`
- Updated Tilt and monitoring docs to match the new flow

Validation
```
$ make docker-build IMG=wandb/operator:dev
$ kind load docker-image wandb/operator:dev --name kind
$ helm dependency update ./deploy/operator

```