### PR TITLE
fix(operator): Pin mysql-operator image to last working tag

### DIFF
--- a/deploy/operator/Chart.lock
+++ b/deploy/operator/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.11.8
 - name: mysql-operator
   repository: https://mysql.github.io/mysql-operator/
-  version: 2.1.10
+  version: 2.1.11
 - name: redis-operator
   repository: https://ot-container-kit.github.io/helm-charts
   version: 0.22.2
@@ -26,5 +26,5 @@ dependencies:
 - name: telemetry
   repository: file://../telemetry
   version: 0.1.0
-digest: sha256:5eb2714834dd8f6d5f5ebf80ac5bb783648193ed3faa43d60b0dc69cc1c44869
-generated: "2026-04-24T09:02:54.051615-07:00"
+digest: sha256:5c5daff2a714cdb07ba63eaddf959d8cec28b255371d210958ca571e305bce59
+generated: "2026-05-07T11:45:06.981528-05:00"

--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: https://charts.wandb.ai/
     condition: wandb-operator.enabled
   - name: mysql-operator
-    version: 2.1.10
+    version: 2.1.11
     repository: https://mysql.github.io/mysql-operator/
     condition: mysql-operator.enabled
   - name: redis-operator

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -119,6 +119,10 @@ wandb-operator:
 
 mysql-operator:
   install: true
+  image:
+    # Oracle never published as image tag with 2.1.11 — their registry only has 8.4.8-2.1.10 to 9.x.
+    # Pin to the last working 2.1.x image.
+    tag: "8.4.8-2.1.10"
 
 redis-operator:
   install: true


### PR DESCRIPTION
# Summary of Issue

We can observe that currently the mysql operator pod is in `ImagePullBackOff` and the MySQL init job fails.

In this PR, we're updating chart version to `2.1.11` since version`2.1.10` is delisted from the upstream helm index [LINK](https://artifacthub.io/packages/helm/mysql-operator/mysql-operator):

<img width="758" height="308" alt="Screenshot 2026-05-11 at 3 59 16 PM" src="https://github.com/user-attachments/assets/49228650-c457-42c4-bf92-a81d5c2f91db" />

From updating it, we can see chart `mysql-operator-2.1.11` ships `appVersion: 8.4.9-2.1.11`, but Oracle never published a matching image [LINK](https://container-registry.oracle.com/ords/f?p=113:4:6627601383547:::::) — their registry jumps `8.4.8-2.1.10 → 9.0.0-2.2.0`, even though it's stated on their documentation [LINK](https://dev.mysql.com/doc/relnotes/mysql-operator/en/news-8-4-9-2.1.11.html):

<img width="1025" height="589" alt="Screenshot 2026-05-11 at 4 07 55 PM" src="https://github.com/user-attachments/assets/84d76524-fb96-4618-b93d-7df973f0df78" />


## Testing

Operator spins up with `tilt up` and can access the login page:
<img width="1028" height="503" alt="Screenshot 2026-05-11 at 3 58 20 PM" src="https://github.com/user-attachments/assets/67b64d23-edeb-4079-b50f-c248cf3985b7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)