### PR TITLE
feat(hardening): Adds container hardening profiles

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -338,8 +338,8 @@ def build_operator_values(telemetry_namespace):
             },
         }
         values["wandb-operator"]["containers"]["operator"]["env"] = {
-            "KAFKA_FSGROUP": {
-                "value": "0",
+            "OPENSHIFT": {
+                "value": "true",
             },
         }
         values["wandb-operator"]["containers"]["operator"]["securityContext"] = {

--- a/Tiltfile
+++ b/Tiltfile
@@ -533,11 +533,29 @@ cert_manager_flags = [
 cert_manager_deps = []
 
 if LOCAL_NETWORKING_MODE == "gateway":
-    local_resource(
-        "gateway-api-crds",
-        "kubectl apply -f " + GATEWAY_API_CRDS_URL,
-        labels=[GROUP_DEPENDENCIES],
-    )
+    if settings.get("openshiftSCC"):
+        # OpenShift Ingress Operator owns Gateway API CRDs via a
+        # ValidatingAdmissionPolicy and blocks kubectl apply. Just assert
+        # the CRDs the wandb chart actually uses are present.
+        gateway_crd_check = (
+            "kubectl get crd "
+            + "gatewayclasses.gateway.networking.k8s.io "
+            + "gateways.gateway.networking.k8s.io "
+            + "httproutes.gateway.networking.k8s.io "
+            + "referencegrants.gateway.networking.k8s.io "
+            + "grpcroutes.gateway.networking.k8s.io"
+        )
+        local_resource(
+            "gateway-api-crds",
+            gateway_crd_check,
+            labels=[GROUP_DEPENDENCIES],
+        )
+    else:
+        local_resource(
+            "gateway-api-crds",
+            "kubectl apply -f " + GATEWAY_API_CRDS_URL,
+            labels=[GROUP_DEPENDENCIES],
+        )
     cert_manager_flags.append("--set=config.enableGatewayAPI=true")
     cert_manager_deps.append("gateway-api-crds")
 
@@ -689,7 +707,8 @@ if as_bool(settings.get("includeCR")):
             local_host=endpoint_host,
             pod_selector={
                 "app.kubernetes.io/instance": "nginx-gateway-fabric",
-                "app.kubernetes.io/name": "nginx-gateway-fabric",
+                "app.kubernetes.io/managed-by": "nginx-gateway-fabric-nginx",
+                "gateway.networking.k8s.io/gateway-name": "wandb-gateway",
             },
             labels=[GROUP_WANDB_APP],
         )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,7 +101,7 @@ func main() {
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
 	var deployerAPI, isolationNamespaces string
-	var debug, airgapped, enableV2, enableWebhooks, enableRollouts, telemetryEnabled bool
+	var debug, airgapped, enableV2, enableWebhooks, enableRollouts, telemetryEnabled, openshift bool
 	var telemetryManagedNamespace string
 	var telemetryOTelSecretName, telemetryOTelProtocol, telemetryOTelServiceName, telemetryOTelResourceAttributes string
 
@@ -132,6 +132,7 @@ func main() {
 	flag.BoolVar(&enableV2, "enable-v2", true, "Use V2 of WandB CRD")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable webhooks")
 	flag.BoolVar(&enableRollouts, "enable-rollouts", false, "Enable Argo Rollout Support")
+	flag.BoolVar(&openshift, "openshift", false, "Enable OpenShift-compatible rendering for managed infrastructure pods")
 	flag.BoolVar(&telemetryEnabled, "telemetry-enabled", false, "Enable telemetry endpoint reconciliation for W&B applications")
 	flag.StringVar(&telemetryManagedNamespace, "telemetry-managed-namespace", "", "Namespace where managed telemetry services run")
 	flag.StringVar(&telemetryOTelSecretName, "telemetry-otel-secret-name", "wandb-otel-connection", "Name of the OTEL connection secret managed by the operator")
@@ -145,6 +146,8 @@ func main() {
 
 	setFlagsFromEnvironment()
 	flag.Parse()
+
+	utils.SetOpenShiftMode(openshift)
 
 	var slogLevel slog.Level
 	switch strings.ToLower(*logLevel) {

--- a/config/openshift-dev/README.md
+++ b/config/openshift-dev/README.md
@@ -58,7 +58,7 @@ When Tilt detects a CRC context, it automatically:
 - Applies `deploy/operator/profiles/openshift.yaml` to the operator Helm release
 - Builds the operator image with a non-root, group-writable `/helm` directory
 - Removes fixed pod UID/GID/fsGroup settings from the local operator deployment
-- Sets `KAFKA_FSGROUP=0` so Strimzi-managed Kafka pods satisfy OpenShift SCCs
+- Sets `OPENSHIFT=true` so managed dependency specs omit fixed IDs and satisfy OpenShift SCCs
 - Pushes images to CRC's internal registry (`default-route-openshift-image-registry.apps-crc.testing`)
 
 ### Security settings

--- a/deploy/operator/profiles/openshift.yaml
+++ b/deploy/operator/profiles/openshift.yaml
@@ -1,8 +1,29 @@
+wandb-operator:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    fsGroupChangePolicy: null
+    seccompProfile:
+      type: RuntimeDefault
+
+  containers:
+    operator:
+      env:
+        OPENSHIFT:
+          value: "true"
+
 grafana-operator:
   isOpenShift: true
 
 minio-operator:
   operator:
+    env:
+      - name: OPERATOR_STS_ENABLED
+        value: "on"
+      - name: MINIO_OPERATOR_RUNTIME
+        value: "OpenShift"
     securityContext:
       runAsUser: null
       runAsGroup: null
@@ -10,3 +31,7 @@ minio-operator:
     containerSecurityContext:
       runAsUser: null
       runAsGroup: null
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/deploy/operator/profiles/openshift.yaml
+++ b/deploy/operator/profiles/openshift.yaml
@@ -8,11 +8,26 @@ wandb-operator:
     seccompProfile:
       type: RuntimeDefault
 
+  # readOnlyRootFilesystem requires writable mounts where the operator
+  # writes manifests and reads serving certs.
+  volumes:
+    - name: server-manifest
+      emptyDir: {}
+    - name: serving-certs
+      secret:
+        secretName: '{{ .Release.Name }}-serving-cert'
+
   containers:
     operator:
       env:
         OPENSHIFT:
           value: "true"
+      volumeMounts:
+        - mountPath: /tmp/server-manifest
+          name: server-manifest
+        - mountPath: /tmp/wandb-operator/serving-certs
+          name: serving-certs
+          readOnly: true
 
 grafana-operator:
   isOpenShift: true
@@ -35,3 +50,25 @@ minio-operator:
       capabilities:
         drop:
           - ALL
+
+# Strimzi's default BaselinePodSecurityProvider injects runAsUser:1001 /
+# runAsGroup:1001 into Kafka pods, which restricted-v2 rejects. Switch the
+# cluster operator to the RestrictedPodSecurityProvider so the platform
+# assigns UID/GID and the pods admit under restricted-v2.
+strimzi-kafka-operator:
+  extraEnvs:
+    - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+      value: restricted
+
+# Override moco images with locally-built copies pushed to the CRC internal
+# registry. Used to test in-development moco changes (UID/SCC fixes) before
+# they ship upstream. Remove once a released chart includes the changes.
+moco:
+  image:
+    repository: image-registry.openshift-image-registry.svc:5000/wandb-operators/moco-controller
+    tag: dev
+    pullPolicy: Always
+  fluentbit:
+    image:
+      repository: image-registry.openshift-image-registry.svc:5000/wandb-operators/moco-fluent-bit
+      tag: dev

--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -981,7 +981,7 @@ func (r *ApplicationReconciler) reconcileHTTPRoute(ctx context.Context, app *wan
 	app.Status.HTTPRouteStatus = summarizeHTTPRouteStatus(httpRoute)
 	logger.Info(fmt.Sprintf("Successfully %s HTTPRoute", op), "HTTPRoute", httpRoute.Name)
 
-	if httpRoute.Status.Parents[0].ControllerName == "networking.gke.io/gateway" {
+	if len(httpRoute.Status.Parents) > 0 && httpRoute.Status.Parents[0].ControllerName == "networking.gke.io/gateway" {
 		healthCheckPolicy := &gkeGatewayApiNetworkingv1.HealthCheckPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      app.Name,

--- a/internal/controller/infra/managed/clickhouse/altinity/spec.go
+++ b/internal/controller/infra/managed/clickhouse/altinity/spec.go
@@ -8,16 +8,98 @@ import (
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/logx"
+	"github.com/wandb/operator/pkg/utils"
 	"github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse.altinity.com/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-const ClickhouseModuleName = "clickhouse"
+const (
+	ClickhouseModuleName = "clickhouse"
+	ClickHouseImage      = "altinity/clickhouse-server:25.8.16.10002.altinitystable"
+)
+
+const (
+	clickHouseRunAsUser  int64 = 101
+	clickHouseRunAsGroup int64 = 101
+	clickHouseFSGroup    int64 = 101
+
+	clickHouseTmpVolumeName = "clickhouse-tmp"
+	clickHouseTmpMountPath  = "/tmp"
+	clickHouseLogVolumeName = "clickhouse-log"
+	clickHouseLogMountPath  = "/var/log/clickhouse-server"
+	clickHouseRunVolumeName = "clickhouse-run"
+	clickHouseRunMountPath  = "/var/run/clickhouse-server"
+
+	clickHouseCapabilityAll corev1.Capability = "ALL"
+)
+
+func clickHousePodSecurityContext() *corev1.PodSecurityContext {
+	if utils.IsOpenShift() {
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot:   ptr.To(true),
+			SeccompProfile: clickHouseRuntimeDefaultSeccompProfile(),
+		}
+	}
+
+	return &corev1.PodSecurityContext{
+		RunAsUser:      ptr.To(clickHouseRunAsUser),
+		RunAsGroup:     ptr.To(clickHouseRunAsGroup),
+		RunAsNonRoot:   ptr.To(true),
+		FSGroup:        ptr.To(clickHouseFSGroup),
+		SeccompProfile: clickHouseRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func clickHouseContainerSecurityContext() *corev1.SecurityContext {
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{clickHouseCapabilityAll},
+		},
+		SeccompProfile: clickHouseRuntimeDefaultSeccompProfile(),
+	}
+	if !utils.IsOpenShift() {
+		securityContext.RunAsUser = ptr.To(clickHouseRunAsUser)
+		securityContext.RunAsGroup = ptr.To(clickHouseRunAsGroup)
+	}
+	return securityContext
+}
+
+func clickHouseWritableVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		writableEmptyDirVolume(clickHouseTmpVolumeName),
+		writableEmptyDirVolume(clickHouseLogVolumeName),
+		writableEmptyDirVolume(clickHouseRunVolumeName),
+	}
+}
+
+func clickHouseWritableVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{Name: clickHouseTmpVolumeName, MountPath: clickHouseTmpMountPath},
+		{Name: clickHouseLogVolumeName, MountPath: clickHouseLogMountPath},
+		{Name: clickHouseRunVolumeName, MountPath: clickHouseRunMountPath},
+	}
+}
+
+func clickHouseRuntimeDefaultSeccompProfile() *corev1.SeccompProfile {
+	return &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+}
+
+func writableEmptyDirVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
 
 // ToClickHouseVendorSpec converts a ClickHouseSpec to a ClickHouseInstallation CR.
 // This function translates the high-level ClickHouse spec into the vendor-specific
@@ -75,7 +157,28 @@ func ToClickHouseVendorSpec(
 		reclaimPolicy = v1.PVCReclaimPolicyDelete
 	}
 
-	// Build ClickHouseInstallation spec
+	podSpec := corev1.PodSpec{
+		SecurityContext: clickHousePodSecurityContext(),
+		Affinity:        wandb.GetAffinity(spec.ManagedInfraSpec),
+		Tolerations:     *wandb.GetTolerations(spec.ManagedInfraSpec),
+		Volumes:         clickHouseWritableVolumes(),
+		Containers: []corev1.Container{
+			{
+				Name:            "clickhouse",
+				Image:           ClickHouseImage,
+				SecurityContext: clickHouseContainerSecurityContext(),
+				VolumeMounts:    clickHouseWritableVolumeMounts(),
+			},
+		},
+	}
+
+	if len(spec.Config.Resources.Requests) > 0 || len(spec.Config.Resources.Limits) > 0 {
+		podSpec.Containers[0].Resources = corev1.ResourceRequirements{
+			Requests: spec.Config.Resources.Requests,
+			Limits:   spec.Config.Resources.Limits,
+		}
+	}
+
 	chi := &v1.ClickHouseInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsnBuilder.InstallationName(),
@@ -111,16 +214,7 @@ func ToClickHouseVendorSpec(
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: BuildWandbClickhouseLabels(wandb),
 						},
-						Spec: corev1.PodSpec{
-							Affinity:    wandb.GetAffinity(spec.ManagedInfraSpec),
-							Tolerations: *wandb.GetTolerations(spec.ManagedInfraSpec),
-							Containers: []corev1.Container{
-								{
-									Name:  "clickhouse",
-									Image: "altinity/clickhouse-server:25.8.16.10002.altinitystable",
-								},
-							},
-						},
+						Spec: podSpec,
 					},
 				},
 				VolumeClaimTemplates: []v1.VolumeClaimTemplate{
@@ -146,31 +240,6 @@ func ToClickHouseVendorSpec(
 				},
 			},
 		},
-	}
-
-	// Add pod template with resources if specified
-	// accessible even though not listed in the pod spec
-	if len(spec.Config.Resources.Requests) > 0 || len(spec.Config.Resources.Limits) > 0 {
-		chi.Spec.Templates.PodTemplates = []v1.PodTemplate{
-			{
-				Name: nsnBuilder.PodTemplateName(),
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: BuildWandbClickhouseLabels(wandb),
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "clickhouse",
-							Resources: corev1.ResourceRequirements{
-								Requests: spec.Config.Resources.Requests,
-								Limits:   spec.Config.Resources.Limits,
-							},
-							Image: "altinity/clickhouse-server:25.8.16.10002.altinitystable",
-						},
-					},
-				},
-			},
-		}
 	}
 
 	// Set owner reference

--- a/internal/controller/infra/managed/clickhouse/altinity/spec_test.go
+++ b/internal/controller/infra/managed/clickhouse/altinity/spec_test.go
@@ -1,0 +1,173 @@
+package altinity
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	chiv1 "github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse.altinity.com/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("ClickHouse vendor specs", func() {
+	BeforeEach(func() {
+		utils.SetOpenShiftMode(false)
+	})
+
+	It("renders hardened pod templates with writable runtime mounts", func() {
+		wandb := clickHouseWandb()
+
+		chi, err := ToClickHouseVendorSpec(context.Background(), wandb, clickHouseScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chi).NotTo(BeNil())
+		Expect(chi.Spec.Templates.PodTemplates).To(HaveLen(1))
+
+		podSpec := chi.Spec.Templates.PodTemplates[0].Spec
+		expectClickHouseDefaultPodSecurityContext(podSpec.SecurityContext)
+		expectClickHouseWritableVolume(podSpec.Volumes, clickHouseTmpVolumeName)
+		expectClickHouseWritableVolume(podSpec.Volumes, clickHouseLogVolumeName)
+		expectClickHouseWritableVolume(podSpec.Volumes, clickHouseRunVolumeName)
+
+		Expect(podSpec.Containers).To(HaveLen(1))
+		container := podSpec.Containers[0]
+		Expect(container.Image).To(Equal(ClickHouseImage))
+		Expect(container.Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("500m")))
+		expectClickHouseDefaultContainerSecurityContext(container.SecurityContext)
+		expectClickHouseWritableMount(container.VolumeMounts, clickHouseTmpVolumeName, clickHouseTmpMountPath)
+		expectClickHouseWritableMount(container.VolumeMounts, clickHouseLogVolumeName, clickHouseLogMountPath)
+		expectClickHouseWritableMount(container.VolumeMounts, clickHouseRunVolumeName, clickHouseRunMountPath)
+	})
+
+	It("omits fixed ClickHouse IDs in OpenShift mode", func() {
+		utils.SetOpenShiftMode(true)
+
+		chi, err := ToClickHouseVendorSpec(context.Background(), clickHouseWandb(), clickHouseScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chi).NotTo(BeNil())
+
+		podSpec := chi.Spec.Templates.PodTemplates[0].Spec
+		expectClickHouseOpenShiftPodSecurityContext(podSpec.SecurityContext)
+		expectClickHouseOpenShiftContainerSecurityContext(podSpec.Containers[0].SecurityContext)
+	})
+})
+
+func clickHouseScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(apiv2.AddToScheme(scheme)).To(Succeed())
+	Expect(chiv1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func clickHouseWandb() *apiv2.WeightsAndBiases {
+	tolerations := []corev1.Toleration{}
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv2.GroupVersion.String(),
+			Kind:       "WeightsAndBiases",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "wandb",
+		},
+		Spec: apiv2.WeightsAndBiasesSpec{
+			Tolerations: &tolerations,
+			ClickHouse: apiv2.ClickHouseSpec{
+				ManagedClickHouse: &apiv2.ManagedClickHouseSpec{
+					Name:        "clickhouse",
+					Namespace:   "wandb",
+					Replicas:    1,
+					StorageSize: "10Gi",
+					Config: apiv2.ClickHouseConfig{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("500m"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func expectClickHouseDefaultPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(clickHouseRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(clickHouseRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.FSGroup).NotTo(BeNil())
+	Expect(*securityContext.FSGroup).To(Equal(clickHouseFSGroup))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectClickHouseDefaultContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(clickHouseRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(clickHouseRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(clickHouseCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectClickHouseWritableMount(mounts []corev1.VolumeMount, name, mountPath string) {
+	found := false
+	for _, mount := range mounts {
+		if mount.Name == name && mount.MountPath == mountPath {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+}
+
+func expectClickHouseOpenShiftPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.FSGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectClickHouseOpenShiftContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(clickHouseCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectClickHouseWritableVolume(volumes []corev1.Volume, name string) {
+	found := false
+	for _, volume := range volumes {
+		if volume.Name == name && volume.EmptyDir != nil {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+}

--- a/internal/controller/infra/managed/kafka/strimzi/spec.go
+++ b/internal/controller/infra/managed/kafka/strimzi/spec.go
@@ -9,11 +9,13 @@ import (
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/logx"
+	"github.com/wandb/operator/pkg/utils"
 	v1 "github.com/wandb/operator/pkg/vendored/strimzi-kafka/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -21,10 +23,18 @@ const (
 	KafkaModuleName      = "kafka"
 	KafkaVersion         = "4.1.0"
 	KafkaMetadataVersion = "4.1-IV0"
+	KafkaImage           = "quay.io/strimzi/kafka:0.49.1-kafka-4.1.0"
 )
 
 const (
 	MetricsReporterType = "strimziMetricsReporter"
+)
+
+const (
+	kafkaRunAsUser  int64 = 1001
+	kafkaRunAsGroup int64 = 1001
+
+	kafkaCapabilityAll corev1.Capability = "ALL"
 )
 
 // createKafkaMetricsConfig creates a MetricsConfig for Kafka if telemetry is enabled.
@@ -43,19 +53,50 @@ func createKafkaMetricsConfig(telemetry apiv2.Telemetry) *v1.MetricsConfig {
 	}
 }
 
-// kafkaPodSecurityContext returns a PodSecurityContext with FSGroup set if the
-// KAFKA_FSGROUP env var is configured on the operator. Returns nil otherwise,
-// allowing the platform to apply its own defaults.
+// kafkaPodSecurityContext keeps the optional KAFKA_FSGROUP override while
+// hardening Strimzi pods with the UID/GID used by the Strimzi images.
 func kafkaPodSecurityContext() *corev1.PodSecurityContext {
+	if utils.IsOpenShift() {
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot:   ptr.To(true),
+			SeccompProfile: kafkaRuntimeDefaultSeccompProfile(),
+		}
+	}
+
+	securityContext := &corev1.PodSecurityContext{
+		RunAsUser:      ptr.To(kafkaRunAsUser),
+		RunAsGroup:     ptr.To(kafkaRunAsGroup),
+		RunAsNonRoot:   ptr.To(true),
+		SeccompProfile: kafkaRuntimeDefaultSeccompProfile(),
+	}
 	val, ok := os.LookupEnv("KAFKA_FSGROUP")
-	if !ok {
-		return nil
+	if ok {
+		if fsGroup, err := strconv.ParseInt(val, 10, 64); err == nil {
+			securityContext.FSGroup = ptr.To(fsGroup)
+		}
 	}
-	fsGroup, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return nil
+
+	return securityContext
+}
+
+func kafkaContainerSecurityContext() *corev1.SecurityContext {
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{kafkaCapabilityAll},
+		},
+		SeccompProfile: kafkaRuntimeDefaultSeccompProfile(),
 	}
-	return &corev1.PodSecurityContext{FSGroup: &fsGroup}
+	if !utils.IsOpenShift() {
+		securityContext.RunAsUser = ptr.To(kafkaRunAsUser)
+		securityContext.RunAsGroup = ptr.To(kafkaRunAsGroup)
+	}
+	return securityContext
+}
+
+func kafkaRuntimeDefaultSeccompProfile() *corev1.SeccompProfile {
+	return &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
 }
 
 // ToKafkaVendorSpec converts a KafkaSpec to a Kafka CR.
@@ -121,8 +162,9 @@ func ToKafkaVendorSpec(
 						Metadata: &v1.MetadataTemplate{
 							Labels: BuildWandbKafkaLabels(wandb),
 						},
-						Affinity:    wandb.GetAffinity(infraSpec.ManagedInfraSpec),
-						Tolerations: *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
+						Affinity:        wandb.GetAffinity(infraSpec.ManagedInfraSpec),
+						Tolerations:     *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
+						SecurityContext: kafkaPodSecurityContext(),
 					},
 				},
 			},
@@ -134,8 +176,18 @@ func ToKafkaVendorSpec(
 						Metadata: &v1.MetadataTemplate{
 							Labels: BuildWandbKafkaLabels(wandb),
 						},
-						Affinity:    wandb.GetAffinity(infraSpec.ManagedInfraSpec),
-						Tolerations: *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
+						Affinity:        wandb.GetAffinity(infraSpec.ManagedInfraSpec),
+						Tolerations:     *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
+						SecurityContext: kafkaPodSecurityContext(),
+					},
+					TopicOperatorContainer: &v1.ContainerTemplate{
+						SecurityContext: kafkaContainerSecurityContext(),
+					},
+					UserOperatorContainer: &v1.ContainerTemplate{
+						SecurityContext: kafkaContainerSecurityContext(),
+					},
+					TlsSidecarContainer: &v1.ContainerTemplate{
+						SecurityContext: kafkaContainerSecurityContext(),
 					},
 				},
 			},
@@ -205,6 +257,12 @@ func ToKafkaNodePoolVendorSpec(
 						Labels: BuildWandbKafkaLabels(wandb),
 					},
 					SecurityContext: kafkaPodSecurityContext(),
+				},
+				InitContainer: &v1.ContainerTemplate{
+					SecurityContext: kafkaContainerSecurityContext(),
+				},
+				KafkaContainer: &v1.ContainerTemplate{
+					SecurityContext: kafkaContainerSecurityContext(),
 				},
 				PersistentVolumeClaim: &v1.ResourceTemplate{
 					Metadata: &v1.MetadataTemplate{

--- a/internal/controller/infra/managed/kafka/strimzi/spec_test.go
+++ b/internal/controller/infra/managed/kafka/strimzi/spec_test.go
@@ -1,0 +1,150 @@
+package strimzi
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	v1 "github.com/wandb/operator/pkg/vendored/strimzi-kafka/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Kafka vendor specs", func() {
+	BeforeEach(func() {
+		utils.SetOpenShiftMode(false)
+	})
+
+	It("renders hardened Strimzi templates and preserves KAFKA_FSGROUP", func() {
+		originalFSGroup, hadFSGroup := os.LookupEnv("KAFKA_FSGROUP")
+		Expect(os.Setenv("KAFKA_FSGROUP", "4242")).To(Succeed())
+		DeferCleanup(func() {
+			if hadFSGroup {
+				Expect(os.Setenv("KAFKA_FSGROUP", originalFSGroup)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("KAFKA_FSGROUP")).To(Succeed())
+		})
+
+		wandb := kafkaWandb()
+
+		kafka, err := ToKafkaVendorSpec(context.Background(), wandb, kafkaScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kafka).NotTo(BeNil())
+		expectKafkaDefaultPodSecurityContext(kafka.Spec.Kafka.Template.Pod.SecurityContext, int64(4242))
+		expectKafkaDefaultPodSecurityContext(kafka.Spec.EntityOperator.Template.Pod.SecurityContext, int64(4242))
+		expectKafkaDefaultContainerSecurityContext(kafka.Spec.EntityOperator.Template.TopicOperatorContainer.SecurityContext)
+		expectKafkaDefaultContainerSecurityContext(kafka.Spec.EntityOperator.Template.UserOperatorContainer.SecurityContext)
+		expectKafkaDefaultContainerSecurityContext(kafka.Spec.EntityOperator.Template.TlsSidecarContainer.SecurityContext)
+
+		nodePool, err := ToKafkaNodePoolVendorSpec(context.Background(), wandb, kafkaScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodePool).NotTo(BeNil())
+		expectKafkaDefaultPodSecurityContext(nodePool.Spec.Template.Pod.SecurityContext, int64(4242))
+		expectKafkaDefaultContainerSecurityContext(nodePool.Spec.Template.InitContainer.SecurityContext)
+		expectKafkaDefaultContainerSecurityContext(nodePool.Spec.Template.KafkaContainer.SecurityContext)
+	})
+
+	It("omits fixed Strimzi IDs in OpenShift mode", func() {
+		utils.SetOpenShiftMode(true)
+
+		kafka, err := ToKafkaVendorSpec(context.Background(), kafkaWandb(), kafkaScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kafka).NotTo(BeNil())
+
+		expectKafkaOpenShiftPodSecurityContext(kafka.Spec.Kafka.Template.Pod.SecurityContext)
+		expectKafkaOpenShiftPodSecurityContext(kafka.Spec.EntityOperator.Template.Pod.SecurityContext)
+		expectKafkaOpenShiftContainerSecurityContext(kafka.Spec.EntityOperator.Template.TopicOperatorContainer.SecurityContext)
+	})
+})
+
+func kafkaScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(apiv2.AddToScheme(scheme)).To(Succeed())
+	Expect(v1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func kafkaWandb() *apiv2.WeightsAndBiases {
+	tolerations := []corev1.Toleration{}
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv2.GroupVersion.String(),
+			Kind:       "WeightsAndBiases",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "wandb",
+		},
+		Spec: apiv2.WeightsAndBiasesSpec{
+			Tolerations: &tolerations,
+			Kafka: apiv2.KafkaSpec{
+				ManagedKafka: &apiv2.ManagedKafkaSpec{
+					Name:        "kafka",
+					Namespace:   "wandb",
+					Replicas:    3,
+					StorageSize: "10Gi",
+				},
+			},
+		},
+	}
+}
+
+func expectKafkaDefaultPodSecurityContext(securityContext *corev1.PodSecurityContext, fsGroup int64) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(kafkaRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(kafkaRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.FSGroup).NotTo(BeNil())
+	Expect(*securityContext.FSGroup).To(Equal(fsGroup))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectKafkaDefaultContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(kafkaRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(kafkaRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(kafkaCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectKafkaOpenShiftPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.FSGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectKafkaOpenShiftContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(kafkaCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}

--- a/internal/controller/infra/managed/minio/tenant/spec.go
+++ b/internal/controller/infra/managed/minio/tenant/spec.go
@@ -7,6 +7,7 @@ import (
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/logx"
+	"github.com/wandb/operator/pkg/utils"
 	miniov2 "github.com/wandb/operator/pkg/vendored/minio-operator/minio.min.io/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -22,6 +23,71 @@ const (
 	DevVolumesPerServer   = int32(1)
 	ProdVolumesPerServer  = int32(4)
 )
+
+const (
+	minioRunAsUser  int64 = 1000
+	minioRunAsGroup int64 = 1000
+	minioFSGroup    int64 = 1000
+
+	minioWritableTmpVolumeName = "minio-tmp"
+	minioWritableTmpMountPath  = "/tmp"
+
+	minioCapabilityAll corev1.Capability = "ALL"
+)
+
+func minioPodSecurityContext() *corev1.PodSecurityContext {
+	if utils.IsOpenShift() {
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot:   ptr.Bool(true),
+			SeccompProfile: minioRuntimeDefaultSeccompProfile(),
+		}
+	}
+
+	return &corev1.PodSecurityContext{
+		RunAsUser:      ptr.Int64(minioRunAsUser),
+		RunAsGroup:     ptr.Int64(minioRunAsGroup),
+		RunAsNonRoot:   ptr.Bool(true),
+		FSGroup:        ptr.Int64(minioFSGroup),
+		SeccompProfile: minioRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func minioContainerSecurityContext() *corev1.SecurityContext {
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             ptr.Bool(true),
+		AllowPrivilegeEscalation: ptr.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{minioCapabilityAll},
+		},
+		SeccompProfile: minioRuntimeDefaultSeccompProfile(),
+	}
+	if !utils.IsOpenShift() {
+		securityContext.RunAsUser = ptr.Int64(minioRunAsUser)
+		securityContext.RunAsGroup = ptr.Int64(minioRunAsGroup)
+	}
+	return securityContext
+}
+
+func minioWritableVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: minioWritableTmpVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
+func minioWritableVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{Name: minioWritableTmpVolumeName, MountPath: minioWritableTmpMountPath},
+	}
+}
+
+func minioRuntimeDefaultSeccompProfile() *corev1.SeccompProfile {
+	return &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+}
 
 func createObjectStoreTelemetryEnv(telemetry apiv2.Telemetry) []corev1.EnvVar {
 	if !telemetry.Enabled {
@@ -68,7 +134,9 @@ func ToObjectStoreVendorSpec(
 			},
 		},
 		Spec: miniov2.TenantSpec{
-			Image: MinioImage,
+			Image:     MinioImage,
+			Mountpath: miniov2.MinIOVolumeMountPath,
+			Subpath:   miniov2.MinIOVolumeSubPath,
 			Configuration: &corev1.LocalObjectReference{
 				Name: ConfigName(specName),
 			},
@@ -80,11 +148,13 @@ func ToObjectStoreVendorSpec(
 			},
 			Pools: []miniov2.Pool{
 				{
-					Name:             "default",
-					Affinity:         wandb.GetAffinity(infraSpec.ManagedInfraSpec),
-					Tolerations:      *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
-					Servers:          infraSpec.Replicas,
-					VolumesPerServer: volumesPerServer,
+					Name:                     "default",
+					Affinity:                 wandb.GetAffinity(infraSpec.ManagedInfraSpec),
+					Tolerations:              *wandb.GetTolerations(infraSpec.ManagedInfraSpec),
+					Servers:                  infraSpec.Replicas,
+					VolumesPerServer:         volumesPerServer,
+					SecurityContext:          minioPodSecurityContext(),
+					ContainerSecurityContext: minioContainerSecurityContext(),
 					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: BuildWandbObjectStoreLabels(wandb),
@@ -102,6 +172,8 @@ func ToObjectStoreVendorSpec(
 					},
 				},
 			},
+			AdditionalVolumes:      minioWritableVolumes(),
+			AdditionalVolumeMounts: minioWritableVolumeMounts(),
 			Buckets: []miniov2.Bucket{
 				{
 					Name: "bucket",

--- a/internal/controller/infra/managed/minio/tenant/spec_test.go
+++ b/internal/controller/infra/managed/minio/tenant/spec_test.go
@@ -1,0 +1,158 @@
+package tenant
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	miniov2 "github.com/wandb/operator/pkg/vendored/minio-operator/minio.min.io/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("MinIO tenant specs", func() {
+	BeforeEach(func() {
+		utils.SetOpenShiftMode(false)
+	})
+
+	It("renders hardened pool settings and writable tmp mount", func() {
+		wandb := minioWandb()
+
+		tenant, err := ToObjectStoreVendorSpec(context.Background(), wandb, minioScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tenant).NotTo(BeNil())
+		Expect(tenant.Spec.Mountpath).To(Equal(miniov2.MinIOVolumeMountPath))
+		Expect(tenant.Spec.Subpath).To(Equal(miniov2.MinIOVolumeSubPath))
+
+		Expect(tenant.Spec.Pools).To(HaveLen(1))
+		pool := tenant.Spec.Pools[0]
+		expectMinioDefaultPodSecurityContext(pool.SecurityContext)
+		expectMinioDefaultContainerSecurityContext(pool.ContainerSecurityContext)
+		expectMinioWritableVolume(tenant.Spec.AdditionalVolumes, minioWritableTmpVolumeName)
+		expectMinioWritableMount(tenant.Spec.AdditionalVolumeMounts, minioWritableTmpVolumeName, minioWritableTmpMountPath)
+	})
+
+	It("omits fixed MinIO IDs in OpenShift mode", func() {
+		utils.SetOpenShiftMode(true)
+
+		tenant, err := ToObjectStoreVendorSpec(context.Background(), minioWandb(), minioScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tenant).NotTo(BeNil())
+
+		pool := tenant.Spec.Pools[0]
+		expectMinioOpenShiftPodSecurityContext(pool.SecurityContext)
+		expectMinioOpenShiftContainerSecurityContext(pool.ContainerSecurityContext)
+	})
+})
+
+func minioScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(apiv2.AddToScheme(scheme)).To(Succeed())
+	Expect(miniov2.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func minioWandb() *apiv2.WeightsAndBiases {
+	tolerations := []corev1.Toleration{}
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv2.GroupVersion.String(),
+			Kind:       "WeightsAndBiases",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "wandb",
+		},
+		Spec: apiv2.WeightsAndBiasesSpec{
+			Tolerations: &tolerations,
+			ObjectStore: apiv2.ObjectStoreSpec{
+				ManagedObjectStore: &apiv2.ManagedObjectStoreSpec{
+					Name:        "minio",
+					Namespace:   "wandb",
+					Replicas:    1,
+					StorageSize: "10Gi",
+				},
+			},
+		},
+	}
+}
+
+func expectMinioDefaultPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(minioRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(minioRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.FSGroup).NotTo(BeNil())
+	Expect(*securityContext.FSGroup).To(Equal(minioFSGroup))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMinioDefaultContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(minioRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(minioRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(minioCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMinioWritableVolume(volumes []corev1.Volume, name string) {
+	found := false
+	for _, volume := range volumes {
+		if volume.Name == name && volume.EmptyDir != nil {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+}
+
+func expectMinioWritableMount(mounts []corev1.VolumeMount, name, mountPath string) {
+	found := false
+	for _, mount := range mounts {
+		if mount.Name == name && mount.MountPath == mountPath {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+}
+
+func expectMinioOpenShiftPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.FSGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMinioOpenShiftContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(minioCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}

--- a/internal/controller/infra/managed/mysql/moco/spec.go
+++ b/internal/controller/infra/managed/mysql/moco/spec.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	mococonstants "github.com/cybozu-go/moco/pkg/constants"
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/common"
+	"github.com/wandb/operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +19,16 @@ import (
 
 const (
 	MysqlModuleName           = "moco"
+	MocoMySQLImage            = "ghcr.io/cybozu-go/moco/mysql:8.4.8"
 	DefaultMySQLExporterImage = "prom/mysqld-exporter:v0.15.1"
+)
+
+const (
+	mocoMySQLRunAsUser  int64 = mococonstants.ContainerUID
+	mocoMySQLRunAsGroup int64 = mococonstants.ContainerGID
+	mocoMySQLFSGroup    int64 = mococonstants.ContainerGID
+
+	mocoMySQLCapabilityAll corev1.Capability = "ALL"
 )
 
 func ToMocoMySQLClusterSpec(
@@ -53,7 +64,8 @@ func ToMocoMySQLClusterSpec(
 			Replicas:           replicas,
 			MySQLConfigMapName: ptr.To(MyCnfConfigMapName(spec.Name)),
 			PodTemplate: mocov1beta2.PodTemplateSpec{
-				Spec: buildMocoPodSpec(spec.Config.Resources),
+				Spec:                buildMocoPodSpec(spec.Config.Resources),
+				OverwriteContainers: mocoOverwriteContainers(),
 			},
 			VolumeClaimTemplates: []mocov1beta2.PersistentVolumeClaim{
 				{
@@ -72,7 +84,8 @@ func ToMocoMySQLClusterSpec(
 func buildMocoPodSpec(resources corev1.ResourceRequirements) mocov1beta2.PodSpecApplyConfiguration {
 	container := corev1ac.Container().
 		WithName("mysqld").
-		WithImage("ghcr.io/cybozu-go/moco/mysql:8.4.8")
+		WithImage(MocoMySQLImage).
+		WithSecurityContext(mocoContainerSecurityContext())
 
 	if resources.Requests != nil || resources.Limits != nil {
 		container = container.WithResources(
@@ -82,8 +95,62 @@ func buildMocoPodSpec(resources corev1.ResourceRequirements) mocov1beta2.PodSpec
 		)
 	}
 
-	podSpec := corev1ac.PodSpec().WithContainers(container)
+	podSpec := corev1ac.PodSpec().
+		WithSecurityContext(mocoPodSecurityContext()).
+		WithContainers(container)
 	return mocov1beta2.PodSpecApplyConfiguration(*podSpec)
+}
+
+func mocoPodSecurityContext() *corev1ac.PodSecurityContextApplyConfiguration {
+	securityContext := corev1ac.PodSecurityContext().
+		WithRunAsNonRoot(true).
+		WithSeccompProfile(corev1ac.SeccompProfile().
+			WithType(corev1.SeccompProfileTypeRuntimeDefault))
+	if !utils.IsOpenShift() {
+		securityContext = securityContext.
+			WithRunAsUser(mocoMySQLRunAsUser).
+			WithRunAsGroup(mocoMySQLRunAsGroup).
+			WithFSGroup(mocoMySQLFSGroup).
+			WithFSGroupChangePolicy(corev1.FSGroupChangeOnRootMismatch)
+	}
+	return securityContext
+}
+
+func mocoContainerSecurityContext() *corev1ac.SecurityContextApplyConfiguration {
+	securityContext := corev1ac.SecurityContext().
+		WithRunAsNonRoot(true).
+		WithAllowPrivilegeEscalation(false).
+		WithCapabilities(corev1ac.Capabilities().WithDrop(mocoMySQLCapabilityAll)).
+		WithSeccompProfile(corev1ac.SeccompProfile().
+			WithType(corev1.SeccompProfileTypeRuntimeDefault))
+	if !utils.IsOpenShift() {
+		securityContext = securityContext.
+			WithRunAsUser(mocoMySQLRunAsUser).
+			WithRunAsGroup(mocoMySQLRunAsGroup)
+	}
+	return securityContext
+}
+
+func mocoOverwriteContainers() []mocov1beta2.OverwriteContainer {
+	securityContext := (*mocov1beta2.SecurityContextApplyConfiguration)(mocoContainerSecurityContext())
+	return []mocov1beta2.OverwriteContainer{
+		{
+			Name:            mocov1beta2.AgentContainerName,
+			SecurityContext: securityContext.DeepCopy(),
+		},
+		{
+			Name:            mocov1beta2.InitContainerName,
+			SecurityContext: securityContext.DeepCopy(),
+		},
+		{
+			Name:            mocov1beta2.SlowQueryLogAgentContainerName,
+			SecurityContext: securityContext.DeepCopy(),
+		},
+		{
+			Name:            mocov1beta2.ExporterContainerName,
+			SecurityContext: securityContext.DeepCopy(),
+		},
+	}
 }
 
 func buildPVCSpec(storageSize string) mocov1beta2.PersistentVolumeClaimSpecApplyConfiguration {

--- a/internal/controller/infra/managed/mysql/moco/spec_test.go
+++ b/internal/controller/infra/managed/mysql/moco/spec_test.go
@@ -1,0 +1,159 @@
+package moco
+
+import (
+	"context"
+
+	mocov1beta2 "github.com/cybozu-go/moco/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+var _ = Describe("Moco MySQL specs", func() {
+	BeforeEach(func() {
+		utils.SetOpenShiftMode(false)
+	})
+
+	It("renders hardened pod and container security settings", func() {
+		cluster, _, err := ToMocoMySQLClusterSpec(
+			context.Background(),
+			apiv2.ManagedMysqlSpec{
+				Name:        "mysql",
+				Namespace:   "wandb",
+				Replicas:    3,
+				StorageSize: "10Gi",
+			},
+			mocoWandb(),
+			mocoScheme(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+
+		podSpec := cluster.Spec.PodTemplate.Spec
+		expectMocoPodSecurityContext(podSpec.SecurityContext)
+		Expect(podSpec.Containers).To(HaveLen(1))
+		Expect(*podSpec.Containers[0].Name).To(Equal("mysqld"))
+		expectMocoContainerSecurityContext(podSpec.Containers[0].SecurityContext)
+
+		Expect(cluster.Spec.PodTemplate.OverwriteContainers).To(HaveLen(4))
+		for _, overwrite := range cluster.Spec.PodTemplate.OverwriteContainers {
+			Expect(overwrite.Name).To(BeElementOf(
+				mocov1beta2.AgentContainerName,
+				mocov1beta2.InitContainerName,
+				mocov1beta2.SlowQueryLogAgentContainerName,
+				mocov1beta2.ExporterContainerName,
+			))
+			Expect(overwrite.SecurityContext).NotTo(BeNil())
+			expectMocoContainerSecurityContext((*corev1ac.SecurityContextApplyConfiguration)(overwrite.SecurityContext))
+		}
+	})
+
+	It("omits fixed Moco IDs in OpenShift mode", func() {
+		utils.SetOpenShiftMode(true)
+
+		cluster, _, err := ToMocoMySQLClusterSpec(
+			context.Background(),
+			apiv2.ManagedMysqlSpec{
+				Name:        "mysql",
+				Namespace:   "wandb",
+				Replicas:    3,
+				StorageSize: "10Gi",
+			},
+			mocoWandb(),
+			mocoScheme(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+
+		podSpec := cluster.Spec.PodTemplate.Spec
+		expectMocoOpenShiftPodSecurityContext(podSpec.SecurityContext)
+		expectMocoOpenShiftContainerSecurityContext(podSpec.Containers[0].SecurityContext)
+	})
+})
+
+func mocoScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(apiv2.AddToScheme(scheme)).To(Succeed())
+	Expect(mocov1beta2.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func mocoWandb() *apiv2.WeightsAndBiases {
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv2.GroupVersion.String(),
+			Kind:       "WeightsAndBiases",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "wandb",
+		},
+	}
+}
+
+func expectMocoPodSecurityContext(securityContext *corev1ac.PodSecurityContextApplyConfiguration) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(mocoMySQLRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(mocoMySQLRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.FSGroup).NotTo(BeNil())
+	Expect(*securityContext.FSGroup).To(Equal(mocoMySQLFSGroup))
+	Expect(securityContext.FSGroupChangePolicy).NotTo(BeNil())
+	Expect(*securityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).NotTo(BeNil())
+	Expect(*securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMocoContainerSecurityContext(securityContext *corev1ac.SecurityContextApplyConfiguration) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(mocoMySQLRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(mocoMySQLRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(mocoMySQLCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).NotTo(BeNil())
+	Expect(*securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMocoOpenShiftPodSecurityContext(securityContext *corev1ac.PodSecurityContextApplyConfiguration) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.FSGroup).To(BeNil())
+	Expect(securityContext.FSGroupChangePolicy).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).NotTo(BeNil())
+	Expect(*securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectMocoOpenShiftContainerSecurityContext(securityContext *corev1ac.SecurityContextApplyConfiguration) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(mocoMySQLCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).NotTo(BeNil())
+	Expect(*securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}

--- a/internal/controller/infra/managed/redis/opstree/spec.go
+++ b/internal/controller/infra/managed/redis/opstree/spec.go
@@ -7,6 +7,7 @@ import (
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/logx"
+	"github.com/wandb/operator/pkg/utils"
 	rediscommon "github.com/wandb/operator/pkg/vendored/redis-operator/common/v1beta2"
 	redisv1beta2 "github.com/wandb/operator/pkg/vendored/redis-operator/redis/v1beta2"
 	redisreplicationv1beta2 "github.com/wandb/operator/pkg/vendored/redis-operator/redisreplication/v1beta2"
@@ -16,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/ptr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -33,6 +34,75 @@ const (
 	DefaultRedisExporterPort  = 9121
 )
 
+const (
+	redisRunAsUser  int64 = 1000
+	redisRunAsGroup int64 = 1000
+	redisFSGroup    int64 = 1000
+
+	redisWritableTmpVolumeName = "redis-tmp"
+	redisWritableTmpMountPath  = "/tmp"
+
+	redisCapabilityAll corev1.Capability = "ALL"
+)
+
+func redisPodSecurityContext() *corev1.PodSecurityContext {
+	if utils.IsOpenShift() {
+		return &corev1.PodSecurityContext{
+			RunAsNonRoot:   ptr.To(true),
+			SeccompProfile: redisRuntimeDefaultSeccompProfile(),
+		}
+	}
+
+	return &corev1.PodSecurityContext{
+		RunAsUser:      ptr.To(redisRunAsUser),
+		RunAsGroup:     ptr.To(redisRunAsGroup),
+		RunAsNonRoot:   ptr.To(true),
+		FSGroup:        ptr.To(redisFSGroup),
+		SeccompProfile: redisRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func redisContainerSecurityContext() *corev1.SecurityContext {
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{redisCapabilityAll},
+		},
+		SeccompProfile: redisRuntimeDefaultSeccompProfile(),
+	}
+	if !utils.IsOpenShift() {
+		securityContext.RunAsUser = ptr.To(redisRunAsUser)
+		securityContext.RunAsGroup = ptr.To(redisRunAsGroup)
+	}
+	return securityContext
+}
+
+func redisWritableVolumeMount() rediscommon.AdditionalVolume {
+	return rediscommon.AdditionalVolume{
+		Volume: []corev1.Volume{
+			{
+				Name: redisWritableTmpVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+		MountPath: []corev1.VolumeMount{
+			{Name: redisWritableTmpVolumeName, MountPath: redisWritableTmpMountPath},
+		},
+	}
+}
+
+func redisAdditionalVolumePtr() *rediscommon.AdditionalVolume {
+	volumeMount := redisWritableVolumeMount()
+	return &volumeMount
+}
+
+func redisRuntimeDefaultSeccompProfile() *corev1.SeccompProfile {
+	return &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}
+}
+
 // createRedisExporterConfig creates a RedisExporter configuration if telemetry is enabled.
 // Returns nil if telemetry is disabled.
 func createRedisExporterConfig(telemetry apiv2.Telemetry) *rediscommon.RedisExporter {
@@ -46,6 +116,7 @@ func createRedisExporterConfig(telemetry apiv2.Telemetry) *rediscommon.RedisExpo
 		Port:            &port,
 		Image:           DefaultRedisExporterImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: redisContainerSecurityContext(),
 	}
 }
 
@@ -87,11 +158,10 @@ func ToRedisStandaloneVendorSpec(
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       &corev1.ResourceRequirements{},
 			},
-			Affinity: wandb.GetAffinity(spec.ManagedInfraSpec),
-			PodSecurityContext: &corev1.PodSecurityContext{
-				FSGroup: ptr.Int64(1000),
-			},
-			Tolerations: wandb.GetTolerations(spec.ManagedInfraSpec),
+			Affinity:           wandb.GetAffinity(spec.ManagedInfraSpec),
+			PodSecurityContext: redisPodSecurityContext(),
+			SecurityContext:    redisContainerSecurityContext(),
+			Tolerations:        wandb.GetTolerations(spec.ManagedInfraSpec),
 			Storage: &rediscommon.Storage{
 				VolumeClaimTemplate: corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
@@ -108,6 +178,7 @@ func ToRedisStandaloneVendorSpec(
 						},
 					},
 				},
+				VolumeMount: redisWritableVolumeMount(),
 			},
 		},
 	}
@@ -172,11 +243,11 @@ func ToRedisSentinelVendorSpec(
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       &corev1.ResourceRequirements{},
 			},
-			PodSecurityContext: &corev1.PodSecurityContext{
-				FSGroup: ptr.Int64(1000),
-			},
-			Affinity:    wandb.GetAffinity(spec.ManagedInfraSpec),
-			Tolerations: wandb.GetTolerations(spec.ManagedInfraSpec),
+			PodSecurityContext: redisPodSecurityContext(),
+			SecurityContext:    redisContainerSecurityContext(),
+			Affinity:           wandb.GetAffinity(spec.ManagedInfraSpec),
+			Tolerations:        wandb.GetTolerations(spec.ManagedInfraSpec),
+			VolumeMount:        redisAdditionalVolumePtr(),
 			RedisSentinelConfig: &redissentinelv1beta2.RedisSentinelConfig{
 				RedisSentinelConfig: rediscommon.RedisSentinelConfig{
 					RedisReplicationName: nsnBuilder.ReplicationName(),
@@ -250,11 +321,10 @@ func ToRedisReplicationVendorSpec(
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       &corev1.ResourceRequirements{},
 			},
-			PodSecurityContext: &corev1.PodSecurityContext{
-				FSGroup: ptr.Int64(1000),
-			},
-			Affinity:    wandb.GetAffinity(spec.ManagedInfraSpec),
-			Tolerations: wandb.GetTolerations(spec.ManagedInfraSpec),
+			PodSecurityContext: redisPodSecurityContext(),
+			SecurityContext:    redisContainerSecurityContext(),
+			Affinity:           wandb.GetAffinity(spec.ManagedInfraSpec),
+			Tolerations:        wandb.GetTolerations(spec.ManagedInfraSpec),
 			Storage: &rediscommon.Storage{
 				VolumeClaimTemplate: corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
@@ -271,6 +341,7 @@ func ToRedisReplicationVendorSpec(
 						},
 					},
 				},
+				VolumeMount: redisWritableVolumeMount(),
 			},
 		},
 	}

--- a/internal/controller/infra/managed/redis/opstree/spec_test.go
+++ b/internal/controller/infra/managed/redis/opstree/spec_test.go
@@ -1,0 +1,166 @@
+package opstree
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	redisv1beta2 "github.com/wandb/operator/pkg/vendored/redis-operator/redis/v1beta2"
+	redisreplicationv1beta2 "github.com/wandb/operator/pkg/vendored/redis-operator/redisreplication/v1beta2"
+	redissentinelv1beta2 "github.com/wandb/operator/pkg/vendored/redis-operator/redissentinel/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Redis vendor specs", func() {
+	BeforeEach(func() {
+		utils.SetOpenShiftMode(false)
+	})
+
+	It("renders hardened standalone Redis settings", func() {
+		wandb := redisWandb(false)
+
+		redis, err := ToRedisStandaloneVendorSpec(context.Background(), wandb, redisScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(redis).NotTo(BeNil())
+
+		expectRedisDefaultPodSecurityContext(redis.Spec.PodSecurityContext)
+		expectRedisDefaultContainerSecurityContext(redis.Spec.SecurityContext)
+		expectRedisWritableTmpMount(redis.Spec.Storage.VolumeMount.MountPath)
+		Expect(redis.Spec.RedisExporter).NotTo(BeNil())
+		expectRedisDefaultContainerSecurityContext(redis.Spec.RedisExporter.SecurityContext)
+	})
+
+	It("renders hardened sentinel and replication Redis settings", func() {
+		wandb := redisWandb(true)
+
+		sentinel, err := ToRedisSentinelVendorSpec(context.Background(), wandb, redisScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sentinel).NotTo(BeNil())
+		expectRedisDefaultPodSecurityContext(sentinel.Spec.PodSecurityContext)
+		expectRedisDefaultContainerSecurityContext(sentinel.Spec.SecurityContext)
+		Expect(sentinel.Spec.VolumeMount).NotTo(BeNil())
+		expectRedisWritableTmpMount(sentinel.Spec.VolumeMount.MountPath)
+
+		replication, err := ToRedisReplicationVendorSpec(context.Background(), wandb, redisScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replication).NotTo(BeNil())
+		expectRedisDefaultPodSecurityContext(replication.Spec.PodSecurityContext)
+		expectRedisDefaultContainerSecurityContext(replication.Spec.SecurityContext)
+		expectRedisWritableTmpMount(replication.Spec.Storage.VolumeMount.MountPath)
+	})
+
+	It("omits fixed Redis IDs in OpenShift mode", func() {
+		utils.SetOpenShiftMode(true)
+
+		redis, err := ToRedisStandaloneVendorSpec(context.Background(), redisWandb(false), redisScheme())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(redis).NotTo(BeNil())
+
+		expectOpenShiftPodSecurityContext(redis.Spec.PodSecurityContext)
+		expectOpenShiftContainerSecurityContext(redis.Spec.SecurityContext)
+		expectRedisWritableTmpMount(redis.Spec.Storage.VolumeMount.MountPath)
+	})
+})
+
+func redisScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(apiv2.AddToScheme(scheme)).To(Succeed())
+	Expect(redisv1beta2.AddToScheme(scheme)).To(Succeed())
+	Expect(redissentinelv1beta2.AddToScheme(scheme)).To(Succeed())
+	Expect(redisreplicationv1beta2.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func redisWandb(sentinel bool) *apiv2.WeightsAndBiases {
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv2.GroupVersion.String(),
+			Kind:       "WeightsAndBiases",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "wandb",
+		},
+		Spec: apiv2.WeightsAndBiasesSpec{
+			Redis: apiv2.RedisSpec{
+				ManagedRedis: &apiv2.ManagedRedisSpec{
+					Name:        "redis",
+					Namespace:   "wandb",
+					StorageSize: "1Gi",
+					Telemetry:   apiv2.Telemetry{Enabled: true},
+					Sentinel:    apiv2.RedisSentinelSpec{Enabled: sentinel},
+				},
+			},
+		},
+	}
+}
+
+func expectRedisDefaultPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(redisRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(redisRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.FSGroup).NotTo(BeNil())
+	Expect(*securityContext.FSGroup).To(Equal(redisFSGroup))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectRedisDefaultContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).NotTo(BeNil())
+	Expect(*securityContext.RunAsUser).To(Equal(redisRunAsUser))
+	Expect(securityContext.RunAsGroup).NotTo(BeNil())
+	Expect(*securityContext.RunAsGroup).To(Equal(redisRunAsGroup))
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(redisCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectRedisWritableTmpMount(mounts []corev1.VolumeMount) {
+	found := false
+	for _, mount := range mounts {
+		if mount.Name == redisWritableTmpVolumeName && mount.MountPath == redisWritableTmpMountPath {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+}
+
+func expectOpenShiftPodSecurityContext(securityContext *corev1.PodSecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.FSGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}
+
+func expectOpenShiftContainerSecurityContext(securityContext *corev1.SecurityContext) {
+	Expect(securityContext).NotTo(BeNil())
+	Expect(securityContext.RunAsUser).To(BeNil())
+	Expect(securityContext.RunAsGroup).To(BeNil())
+	Expect(securityContext.RunAsNonRoot).NotTo(BeNil())
+	Expect(*securityContext.RunAsNonRoot).To(BeTrue())
+	Expect(securityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+	Expect(*securityContext.AllowPrivilegeEscalation).To(BeFalse())
+	Expect(securityContext.Capabilities).NotTo(BeNil())
+	Expect(securityContext.Capabilities.Drop).To(ContainElement(redisCapabilityAll))
+	Expect(securityContext.SeccompProfile).NotTo(BeNil())
+	Expect(securityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+}

--- a/pkg/utils/openshift.go
+++ b/pkg/utils/openshift.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+	"sync/atomic"
+)
+
+var openshiftMode atomic.Bool
+
+func init() {
+	if enabled, err := strconv.ParseBool(os.Getenv("OPENSHIFT")); err == nil && enabled {
+		openshiftMode.Store(true)
+	}
+}
+
+// SetOpenShiftMode enables or disables OpenShift rendering behavior.
+func SetOpenShiftMode(enabled bool) {
+	openshiftMode.Store(enabled)
+}
+
+// IsOpenShift reports whether OpenShift-specific rendering behavior is enabled.
+func IsOpenShift() bool {
+	return openshiftMode.Load()
+}


### PR DESCRIPTION
This PR improves generated managed dependency workload hardening for Redis, Kafka, ClickHouse, MinIO, and Moco MySQL.

Changes include:

- Adds dependency-specific hardening declarations directly in each package’s existing spec.go.
- Renders image-aware runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, allowPrivilegeEscalation: false, and capabilities.drop: [ALL] where supported.
- Adds writable emptyDir mounts for runtime paths that need write access:
  - Redis: /tmp
  - ClickHouse: /tmp, /var/log/clickhouse-server, /var/run/clickhouse-server
  - MinIO: /tmp
 
Taken from #179 -
- Preserves Kafka’s existing KAFKA_FSGROUP override outside OpenShift.
- Adds OpenShift mode via OPENSHIFT=true / --openshift, where managed dependency specs omit fixed UID/GID/fsGroup so restricted SCC admission can assign platform-safe IDs.
- Wires OpenShift mode through the Helm OpenShift profile and Tilt CRC path. 
- Adds focused spec tests for default hardening and OpenShift-compatible rendering across all affected managed dependencies.