### PR TITLE
feat(telemetry): Adding Telemetry Features

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -502,7 +502,14 @@ local_resource(
 local_resource(
     "Operator-Chart-Deps",
     "helm dependency build ./deploy/operator --skip-refresh",
-    deps=["deploy/operator/Chart.yaml", "deploy/operator/Chart.lock", "deploy/telemetry/Chart.yaml"],
+    deps=[
+        "deploy/operator/Chart.yaml",
+        "deploy/operator/Chart.lock",
+        "deploy/telemetry/Chart.yaml",
+        "deploy/telemetry/values.yaml",
+        "deploy/telemetry/templates",
+        "deploy/telemetry/dashboards",
+    ],
     labels=[GROUP_DEPENDENCIES],
 )
 

--- a/deploy/operator/values.schema.json
+++ b/deploy/operator/values.schema.json
@@ -87,6 +87,9 @@
             },
             "infrastructure": {
               "type": "boolean"
+            },
+            "kubeStateMetrics": {
+              "type": "boolean"
             }
           }
         },

--- a/deploy/telemetry/dashboards/wandb-field-investigation.json
+++ b/deploy/telemetry/dashboards/wandb-field-investigation.json
@@ -67,7 +67,7 @@
       "gridPos": {"h": 12, "w": 16, "x": 0, "y": 7},
       "targets": [
         {
-          "expr": "count by (container, image) (container_last_seen{namespace=\"$namespace\", container=~\"api|executor|parquet|glue|filestream|filemeta|flat-run-fields-updater|metric-observer|nginx-proxy|weave|weave-trace|weave-trace-worker|weave-trace-evaluate-model-worker\"})",
+          "expr": "wandb_application_info{namespace=\"$namespace\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -77,9 +77,9 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": {"Time": true, "Value": true},
-            "indexByName": {"container": 0, "image": 1},
-            "renameByName": {"container": "Container", "image": "Image"}
+            "excludeByName": {"Time": true, "Value": true, "__name__": true, "job": true, "instance": true, "namespace": true, "pod": true, "container": true, "endpoint": true, "service": true},
+            "indexByName": {"application_name": 0, "image": 1, "tag": 2, "digest": 3},
+            "renameByName": {"application_name": "Service", "image": "Image", "tag": "Tag", "digest": "Digest"}
           }
         }
       ],
@@ -99,7 +99,7 @@
       "gridPos": {"h": 12, "w": 8, "x": 16, "y": 7},
       "options": {
         "mode": "markdown",
-        "content": "### What is this?\n\nThe currently-running container image for each managed W&B service in this install.\n\n### Why it matters\n\n- **Version lag** — knowing the tag tells you whether a fix has shipped here yet.\n- **Mid-upgrade drift** — if `api` is on a newer tag than `parquet`, a rollout is in progress (or got stuck) and behavior may be inconsistent.\n- **Internal registry** — the image path shows whether services are pulling from your internal mirror.\n\n### How to read it\n\nOne row per `(container, image)` pair observed in the last scrape window. If a container appears with two image rows, that container is mid-rollout."
+        "content": "### What is this?\n\nThe currently-running container image for each managed W&B service in this install, split into image / tag / digest columns.\n\n### Why it matters\n\n- **Version lag** — the tag column tells you whether a fix has shipped here yet.\n- **Mid-upgrade drift** — if `api` is on a newer tag than `parquet`, a rollout is in progress (or got stuck) and behavior may be inconsistent.\n- **Internal registry** — the image path shows whether services are pulling from your internal mirror.\n\n### How to read it\n\nOne row per managed W&B service. If a service appears with two rows, that service is mid-rollout."
       }
     },
     {
@@ -135,7 +135,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       },
       "thresholds": {
@@ -173,7 +173,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -209,7 +209,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },

--- a/deploy/telemetry/dashboards/wandb-managed-install-performance.json
+++ b/deploy/telemetry/dashboards/wandb-managed-install-performance.json
@@ -66,7 +66,7 @@
       "gridPos": {"h": 10, "w": 16, "x": 0, "y": 7},
       "targets": [
         {
-          "expr": "sum by (pod, container) (changes(container_start_time_seconds{namespace=\"$namespace\", container!=\"\", container!=\"POD\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}[1h]))",
+          "expr": "sum by (pod, container) (increase(kube_pod_container_status_restarts_total{namespace=\"$namespace\", container!=\"\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}[1h]))",
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
         }
@@ -91,12 +91,12 @@
     },
     {
       "type": "timeseries",
-      "title": "Top Containers by CPU Usage",
+      "title": "Top Containers by CPU (% of limit)",
       "datasource": {"type": "victoriametrics-metrics-datasource", "uid": "${DS_VICTORIAMETRICS}"},
       "gridPos": {"h": 10, "w": 16, "x": 0, "y": 17},
       "targets": [
         {
-          "expr": "topk(15, sum by (pod, container) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"\", container!=\"POD\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}[$__rate_interval])))",
+          "expr": "topk(15, sum by (pod, container) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"\", container!=\"POD\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}[$__rate_interval])) / on (pod, container) sum by (pod, container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\"}))",
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
         }
@@ -106,7 +106,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -116,27 +116,27 @@
       "gridPos": {"h": 10, "w": 8, "x": 16, "y": 17},
       "options": {
         "mode": "markdown",
-        "content": "### What is this?\n\nTop 15 containers in the selected namespace by CPU usage (in cores), filtering out system/agent containers. Includes both W&B services and the managed infrastructure components (MySQL, Redis, Kafka, MinIO, ClickHouse).\n\n### Why it matters\n\nA container near or above its CPU limit will throttle, slowing every request it handles.\n\n### What to do\n\nFor the configured limit, run `kubectl describe pod -n <namespace> <pod>` and look at the Limits section, or check `spec.size` in the WeightsAndBiases CR. For sustained saturation, increase the install size."
+        "content": "### What is this?\n\nTop 15 containers in the selected namespace by CPU usage as a fraction of the configured CPU limit (1.0 = 100% of limit). Filters out system/agent containers. Includes both W&B services and the managed infrastructure components (MySQL, Redis, Kafka, MinIO, ClickHouse).\n\n### Why it matters\n\nA container sustained above 0.8 (80% of limit) will throttle frequently, slowing every request it handles. Above 1.0 means kernel-side throttling is constant.\n\n### What to do\n\nFor the configured limit, run `kubectl describe pod -n <namespace> <pod>` and look at the Limits section, or check `spec.size` in the WeightsAndBiases CR. For sustained saturation, increase the install size.\n\n*Series will be missing for containers without a configured CPU limit.*"
       }
     },
     {
       "type": "timeseries",
-      "title": "Top Containers by Memory (Working Set)",
+      "title": "Top Containers by Memory (% of limit)",
       "datasource": {"type": "victoriametrics-metrics-datasource", "uid": "${DS_VICTORIAMETRICS}"},
       "gridPos": {"h": 10, "w": 16, "x": 0, "y": 27},
       "targets": [
         {
-          "expr": "topk(15, sum by (pod, container) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"\", container!=\"POD\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}))",
+          "expr": "topk(15, sum by (pod, container) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"\", container!=\"POD\", container!~\"agent|aws.*|csi.*|efs.*|external.*|kube.*|liveness.*|prometheus.*|teleport.*|gke.*\"}) / on (pod, container) sum by (pod, container) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\"}))",
           "legendFormat": "{{pod}} / {{container}}",
           "refId": "A"
         }
       ],
       "fieldConfig": {
-        "defaults": {"unit": "bytes", "min": 0},
+        "defaults": {"unit": "percentunit", "min": 0},
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -146,7 +146,7 @@
       "gridPos": {"h": 10, "w": 8, "x": 16, "y": 27},
       "options": {
         "mode": "markdown",
-        "content": "### What is this?\n\nTop 15 containers in the selected namespace by working-set memory — the part the kernel would not evict.\n\n### Why it matters\n\n- A line that climbs without leveling off suggests a memory leak.\n- A line that spikes and drops to near zero suggests the container was OOMKilled (visible in the Container Restarts panel above).\n- A line consistently near the configured limit means the container is one bad allocation away from OOM.\n\n### What to do\n\nFor OOM debug: `kubectl get events -n <namespace> --sort-by=.lastTimestamp | grep -i oom`. For configured limits, see `spec.size` in the WeightsAndBiases CR."
+        "content": "### What is this?\n\nTop 15 containers in the selected namespace by working-set memory as a fraction of the configured memory limit (1.0 = 100% of limit). Working-set is the memory the kernel will not evict.\n\n### Why it matters\n\n- A line that climbs without leveling off suggests a memory leak.\n- A line that touches 1.0 means the container was OOMKilled (visible in the Container Restarts panel above).\n- A line consistently above 0.85 means the container is one bad allocation away from OOM.\n\n### What to do\n\nFor OOM debug: `kubectl get events -n <namespace> --sort-by=.lastTimestamp | grep -i oom`. For configured limits, see `spec.size` in the WeightsAndBiases CR.\n\n*Series will be missing for containers without a configured memory limit.*"
       }
     },
     {
@@ -182,7 +182,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -227,7 +227,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -267,7 +267,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -315,7 +315,7 @@
         ]
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -355,7 +355,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -396,7 +396,7 @@
         "overrides": []
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -444,7 +444,7 @@
         ]
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       }
     },
@@ -488,7 +488,7 @@
         ]
       },
       "options": {
-        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]},
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "max", "sum"]},
         "tooltip": {"mode": "multi"}
       },
       "thresholds": {

--- a/deploy/telemetry/dashboards/wandb-managed-install-performance.json
+++ b/deploy/telemetry/dashboards/wandb-managed-install-performance.json
@@ -516,12 +516,33 @@
       "collapsed": false
     },
     {
+      "type": "timeseries",
+      "title": "Slowest Storage Operations (p95, by span)",
+      "datasource": {"type": "victoriametrics-metrics-datasource", "uid": "${DS_VICTORIAMETRICS}"},
+      "gridPos": {"h": 10, "w": 16, "x": 0, "y": 123},
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum by (service_name, span_name, le) (rate(traces_spanmetrics_duration_milliseconds_bucket{service_name=~\"gorilla.*\", span_name=~\"(?i)(parquet|filestream|filehandler|runstore|historystore|metadatastore|s3|minio|sql).*\"}[$__rate_interval]))))",
+          "legendFormat": "{{service_name}} / {{span_name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {"unit": "ms", "min": 0},
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["max", "mean"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
       "type": "text",
-      "title": "About: Parquet Read Performance",
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 123},
+      "title": "About: Slow Storage Operations",
+      "gridPos": {"h": 10, "w": 8, "x": 16, "y": 123},
       "options": {
         "mode": "markdown",
-        "content": "Slow chart loads are usually driven by slow parquet reads. Diagnostics for this layer live in the trace explorer rather than as a chart panel:\n\n- [Open Traces in Explore](/explore?panes=%7B%22A%22:%7B%22datasource%22:%22${DS_VICTORIATRACES}%22,%22queries%22:[],%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1), filter `service.name=gorilla` or `service.name=gorilla-parquet` with `duration > 3s`, then narrow by `resource.name` (e.g., `ParquetHistoryStore.FetchHistorySketchWithKeys`, `FileStreamStore.StoreChunks`).\n- The **Slow Operations** table in the [W&B Field Investigation](/d/wandb-field-investigation) dashboard shows the same story from the HTTP-route side — useful for identifying which user-facing operations are most affected.\n- The parquet pod's memory series in the **Container Resource Usage** section above is a leading indicator: sustained near-limit memory plus frequent restarts often correlates with parquet read slowness."
+        "content": "### What is this?\n\np95 latency per storage operation, derived from traces by the OTel `spanmetrics` connector. Covers parquet reads/writes, filestream chunks, MinIO/S3 calls, and SQL statements.\n\n### Why it matters\n\nSlow chart loads, slow file uploads, and stuck artifact downloads almost always trace back to one storage path being slow. This panel surfaces which one without opening individual traces.\n\n### What to do\n\n- Spikes on `ParquetHistoryStore.*` or `HistoryStore.*` → chart loads will feel slow. Check the parquet pod's CPU/memory in **Container Resource Usage** above, and ClickHouse load if installed.\n- Spikes on `FileStreamStore.*` / `FileHandler.*` → ingest stalls. Check filestream container restarts and MinIO capacity below.\n- Spikes on `sql.*` → MySQL is the bottleneck. See **MySQL Errors & Slow Queries** above.\n- For per-request detail, [open Traces in Explore](/explore?panes=%7B%22A%22:%7B%22datasource%22:%22${DS_VICTORIATRACES}%22,%22queries%22:[],%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1) and filter by the offending `service.name` + `span.name` with `duration > 1s`."
       }
     }
   ],

--- a/deploy/telemetry/dashboards/wandb-telemetry-overview.json
+++ b/deploy/telemetry/dashboards/wandb-telemetry-overview.json
@@ -241,7 +241,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_questions{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_questions{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],
@@ -810,7 +810,7 @@
       },
       "targets": [
         {
-          "expr": "max(mysql_up{job=\"default/mysql-innodb\"})",
+          "expr": "max(mysql_up{job=~\".*/mysql-innodb\"})",
           "refId": "A"
         }
       ],
@@ -861,7 +861,7 @@
       },
       "targets": [
         {
-          "expr": "max(mysql_global_status_threads_connected{job=\"default/mysql-innodb\"})",
+          "expr": "max(mysql_global_status_threads_connected{job=~\".*/mysql-innodb\"})",
           "refId": "A"
         }
       ],
@@ -895,7 +895,7 @@
       },
       "targets": [
         {
-          "expr": "max(mysql_global_status_threads_running{job=\"default/mysql-innodb\"})",
+          "expr": "max(mysql_global_status_threads_running{job=~\".*/mysql-innodb\"})",
           "refId": "A"
         }
       ],
@@ -929,7 +929,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],
@@ -963,7 +963,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_slow_queries{job=\"default/mysql-innodb\"}[$__rate_interval])) or vector(0)",
+          "expr": "sum(rate(mysql_global_status_slow_queries{job=~\".*/mysql-innodb\"}[$__rate_interval])) or vector(0)",
           "refId": "A"
         }
       ],
@@ -1018,7 +1018,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "refId": "A"
         }
       ],
@@ -1052,17 +1052,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_questions{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_questions{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "questions",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "innodb writes",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "fsyncs",
           "refId": "C"
         }
@@ -1083,12 +1083,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_bytes_received{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_bytes_received{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "bytes received",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(mysql_global_status_bytes_sent{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_bytes_sent{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "bytes sent",
           "refId": "B"
         }
@@ -1115,12 +1115,12 @@
       },
       "targets": [
         {
-          "expr": "max(mysql_global_status_innodb_row_lock_current_waits{job=\"default/mysql-innodb\"})",
+          "expr": "max(mysql_global_status_innodb_row_lock_current_waits{job=~\".*/mysql-innodb\"})",
           "legendFormat": "current waits",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(mysql_global_status_innodb_row_lock_waits{job=\"default/mysql-innodb\"}[$__rate_interval])) or vector(0)",
+          "expr": "sum(rate(mysql_global_status_innodb_row_lock_waits{job=~\".*/mysql-innodb\"}[$__rate_interval])) or vector(0)",
           "legendFormat": "waits / sec",
           "refId": "B"
         }
@@ -1141,12 +1141,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(mysql_global_status_innodb_data_reads{job=\"default/mysql-innodb\"}[$__rate_interval])) or vector(0)",
+          "expr": "sum(rate(mysql_global_status_innodb_data_reads{job=~\".*/mysql-innodb\"}[$__rate_interval])) or vector(0)",
           "legendFormat": "reads",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=\"default/mysql-innodb\"}[$__rate_interval]))",
+          "expr": "sum(rate(mysql_global_status_innodb_data_writes{job=~\".*/mysql-innodb\"}[$__rate_interval]))",
           "legendFormat": "writes",
           "refId": "B"
         }

--- a/deploy/telemetry/templates/telemetry-otlp-gateway.yaml
+++ b/deploy/telemetry/templates/telemetry-otlp-gateway.yaml
@@ -23,6 +23,22 @@ data:
     processors:
       batch: {}
 
+    connectors:
+      # Derives RED-style metrics (request count + duration histogram) from
+      # incoming traces. service.name and span.name are implicit identity;
+      # http.route is added so dashboards can break down by HTTP route.
+      # Cardinality budget per Phase 2.5: ~50k series. user.id /
+      # project.name / entity.name dimensions are deferred to Wave C.2.
+      spanmetrics:
+        namespace: traces_spanmetrics
+        dimensions:
+          - name: http.route
+            default: ""
+        histogram:
+          explicit:
+            buckets: [5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s]
+        metrics_flush_interval: 15s
+
     exporters:
       otlphttp/vm:
         endpoint: http://vmsingle-{{ include "telemetry.vmsingleName" . }}:8428
@@ -59,7 +75,7 @@ data:
           address: 0.0.0.0:8888
       pipelines:
         metrics:
-          receivers: [otlp]
+          receivers: [otlp, spanmetrics]
           processors: [batch]
           exporters: [otlphttp/vm{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
         logs:
@@ -69,7 +85,7 @@ data:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [otlphttp/vt{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
+          exporters: [otlphttp/vt, spanmetrics{{ if $forwardingEnabled }}, {{ include "telemetry.forwardingExporterName" . }}{{ end }}]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/telemetry/templates/telemetry-scrapes.yaml
+++ b/deploy/telemetry/templates/telemetry-scrapes.yaml
@@ -125,6 +125,32 @@ spec:
     - port: metrics
 {{- end }}
 
+{{- if .Values.scrape.kubeStateMetrics }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: kube-state-metrics
+  namespace: {{ include "telemetry.namespace" . }}
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: wandb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  namespaceSelector:
+    any: true
+  endpoints:
+      # KSM exposes its own pod's namespace/pod labels by default. honorLabels
+      # keeps the metric's intrinsic labels (kube_pod_container_*'s namespace
+      # refers to the *target* pod, which is what dashboards filter on) instead
+      # of letting the target-side namespace overwrite them.
+    - port: http
+      scheme: http
+      honorLabels: true
+{{- end }}
+
 {{- if .Values.scrape.wandbApi }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/deploy/telemetry/templates/telemetry-scrapes.yaml
+++ b/deploy/telemetry/templates/telemetry-scrapes.yaml
@@ -39,14 +39,18 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: operator
-      control-plane: controller-manager
+      app.kubernetes.io/name: wandb-operator
   namespaceSelector:
     matchNames:
-      - operator-system
+      - {{ .Release.Namespace }}
   endpoints:
-    - port: https
+      # The operator emits `wandb_application_info{namespace="<wandb-cr-ns>"}`
+      # where `namespace` is the W&B CR's namespace (what dashboards filter on),
+      # not the operator pod's namespace. honorLabels keeps the metric's label
+      # instead of letting target-side `namespace=wandb-operators` overwrite it.
+    - port: metrics
       scheme: http
+      honorLabels: true
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape

--- a/deploy/telemetry/values.schema.json
+++ b/deploy/telemetry/values.schema.json
@@ -66,6 +66,9 @@
         },
         "infrastructure": {
           "type": "boolean"
+        },
+        "kubeStateMetrics": {
+          "type": "boolean"
         }
       }
     },

--- a/deploy/telemetry/values.yaml
+++ b/deploy/telemetry/values.yaml
@@ -14,6 +14,7 @@ scrape:
   operators: true
   wandbApi: true
   infrastructure: true
+  kubeStateMetrics: true
 alerting:
   enabled: false
   evaluationInterval: 30s

--- a/internal/controller/reconciler/pods.go
+++ b/internal/controller/reconciler/pods.go
@@ -264,7 +264,11 @@ func resolveEnvvars(ctx context.Context, client ctrlClient.Client, wandb *v2.Wei
 			case "telemetry":
 				secretName := src.Name
 				if secretName == "" {
-					continue
+					return nil, fmt.Errorf(
+						"[telemetry] env var %q has a telemetry source with no Name set (typically %q)",
+						env.Name,
+						"wandb-otel-connection",
+					)
 				}
 
 				selector := v1.SecretKeySelector{

--- a/internal/controller/reconciler/reconcile_v2.go
+++ b/internal/controller/reconciler/reconcile_v2.go
@@ -513,7 +513,7 @@ func reconcileApplications(
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		envVars, err = injectManagedWorkloadTelemetryEnvvars(ctx, client, wandb, manifest, app, envVars, telemetryConfig.Enabled)
+		envVars, err = injectManagedWorkloadTelemetryEnvvars(ctx, client, wandb, manifest, app, envVars, telemetryConfig)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -768,18 +768,40 @@ func injectManagedWorkloadTelemetryEnvvars(
 	manifest serverManifest.Manifest,
 	app serverManifest.Application,
 	envVars []corev1.EnvVar,
-	telemetryEnabled bool,
+	telemetryConfig TelemetryRuntimeConfig,
 ) ([]corev1.EnvVar, error) {
+
+	telemetryEnabled := telemetryConfig.Enabled
 	if !telemetryEnabled || !shouldInjectManagedWorkloadTelemetry(app.Name) {
 		return envVars, nil
 	}
 
-	telemetryEnvVars, err := resolveEnvvars(ctx, client, wandb, manifest, nil, managedWorkloadTelemetryEnvVars)
+	// Ensure telemetry `secretName` is present
+	cleanedEnvVars := bindTelemetrySecretName(managedWorkloadTelemetryEnvVars, telemetryConfig.OTel.SecretName)
+
+	telemetryEnvVars, err := resolveEnvvars(ctx, client, wandb, manifest, nil, cleanedEnvVars)
 	if err != nil {
 		return nil, err
 	}
 
 	return appendMissingEnvVars(envVars, telemetryEnvVars), nil
+}
+
+// This function binds the secret name if `secretName` is empty for telemetry.
+func bindTelemetrySecretName(base []serverManifest.EnvVar, secretName string) []serverManifest.EnvVar {
+	output := make([]serverManifest.EnvVar, len(base))
+	for i, envVar := range base {
+		sources := make([]serverManifest.EnvSource, len(envVar.Sources))
+		for j, source := range envVar.Sources {
+			if source.Type == "telemetry" && source.Name == "" {
+				source.Name = secretName
+			}
+			sources[j] = source
+		}
+		envVar.Sources = sources
+		output[i] = envVar
+	}
+	return output
 }
 
 func shouldInjectManagedWorkloadTelemetry(appName string) bool {

--- a/internal/controller/reconciler/reconcile_v2.go
+++ b/internal/controller/reconciler/reconcile_v2.go
@@ -29,6 +29,7 @@ import (
 	apiv2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/operator/internal/controller/ctrlqueue"
 	"github.com/wandb/operator/internal/logx"
+	wmetrics "github.com/wandb/operator/internal/metrics"
 	oputils "github.com/wandb/operator/pkg/utils"
 	serverManifest "github.com/wandb/operator/pkg/wandb/manifest"
 	batchv1 "k8s.io/api/batch/v1"
@@ -603,6 +604,8 @@ func reconcileApplications(
 			}
 		}
 
+		wmetrics.SetApplicationInfo(app.Name, wandb.Namespace, app.Image.Repository, app.Image.Tag, app.Image.Digest)
+
 		wandb.Status.Wandb.Applications[app.Name] = application.Status
 	}
 
@@ -628,6 +631,7 @@ func reconcileApplications(
 				return ctrl.Result{}, fmt.Errorf("failed to delete application %s: %w", app.Name, err)
 			}
 			delete(wandb.Status.Wandb.Applications, appName)
+			wmetrics.DeleteApplicationInfo(appName, wandb.Namespace)
 		}
 	}
 

--- a/internal/controller/reconciler/telemetry_test.go
+++ b/internal/controller/reconciler/telemetry_test.go
@@ -539,7 +539,7 @@ func TestInjectManagedWorkloadTelemetryEnvvarsDisabledSkipsInjection(t *testing.
 		serverManifest.Manifest{},
 		serverManifest.Application{Name: "api"},
 		nil,
-		false,
+		TelemetryRuntimeConfig{Enabled: false},
 	)
 	if err != nil {
 		t.Fatalf("injectManagedWorkloadTelemetryEnvvars returned error: %v", err)
@@ -558,6 +558,66 @@ func mustFindEnvVar(t *testing.T, envs []corev1.EnvVar, name string) corev1.EnvV
 	}
 	t.Fatalf("env var %q not found", name)
 	return corev1.EnvVar{}
+}
+
+func TestInjectManagedWorkloadTelemetryEnvvarsBindsSecretName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding corev1 to scheme: %v", err)
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	wandb := &apiv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb-dev-v2", Namespace: "default"}}
+
+	telemetryConfig := TelemetryRuntimeConfig{
+		Enabled: true,
+		OTel: TelemetryOTelConfig{
+			SecretName:  "wandb-otel-connection",
+			Protocol:    "http/protobuf",
+			ServiceName: "wandb-service",
+		},
+	}
+
+	envVars, err := injectManagedWorkloadTelemetryEnvvars(
+		context.Background(),
+		client,
+		wandb,
+		serverManifest.Manifest{},
+		serverManifest.Application{Name: "api"},
+		nil,
+		telemetryConfig,
+	)
+	if err != nil {
+		t.Fatalf("injectManagedWorkloadTelemetryEnvvars returned error: %v", err)
+	}
+
+	expectedNames := []string{
+		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_TRACES_EXPORTER",
+		"OTEL_METRICS_EXPORTER",
+		"OTEL_LOGS_EXPORTER",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_SERVICE_NAME",
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"GORILLA_TRACER",
+	}
+
+	for _, name := range expectedNames {
+		env := mustFindEnvVar(t, envVars, name)
+
+		if env.ValueFrom == nil {
+			t.Errorf("env var %q has no ValueFrom; expected SecretKeyRef to %q", name, telemetryConfig.OTel.SecretName)
+			continue
+		}
+		if env.ValueFrom.SecretKeyRef == nil {
+			t.Errorf("env var %q ValueFrom has no SecretKeyRef; expected reference to %q", name, telemetryConfig.OTel.SecretName)
+			continue
+		}
+		if got := env.ValueFrom.SecretKeyRef.Name; got != telemetryConfig.OTel.SecretName {
+			t.Errorf("env var %q references secret %q, want %q", name, got, telemetryConfig.OTel.SecretName)
+		}
+	}
 }
 
 //func coreEnvVarSliceContains(envs []corev1.EnvVar, target string) bool {

--- a/internal/controller/weightsandbiases_controller_test.go
+++ b/internal/controller/weightsandbiases_controller_test.go
@@ -50,6 +50,21 @@ var _ = Describe("WeightsAndBiases Controller V2", func() {
 				Namespace: WandbNamespace,
 			},
 		}
+		// Applications are not owned by the WeightsAndBiases CR via OwnerReference
+		// in the envtest setup, so garbage collection doesn't cascade. Without
+		// this explicit pass, Applications from earlier It blocks leak into the
+		// next test's namespace and break assertions that count them.
+		appList := &apiv2.ApplicationList{}
+		if err := k8sClient.List(ctx, appList, client.InNamespace(WandbNamespace)); err == nil {
+			for i := range appList.Items {
+				app := &appList.Items[i]
+				if len(app.Finalizers) > 0 {
+					app.SetFinalizers(nil)
+					_ = k8sClient.Update(ctx, app)
+				}
+				_ = k8sClient.Delete(ctx, app, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			}
+		}
 		Expect(k8sClient.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(SatisfyAny(Succeed(), MatchError(ContainSubstring("not found"))))
 		Expect(k8sClient.Delete(ctx, dbSecret)).Should(SatisfyAny(Succeed(), MatchError(ContainSubstring("not found"))))
 		Expect(k8sClient.Delete(ctx, wandb)).Should(SatisfyAny(Succeed(), MatchError(ContainSubstring("not found"))))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// ApplicationInfo follows the Prometheus "info" pattern: one series per
+// managed W&B Application, value always 1, identity carried in the labels.
+// Dashboards use this to render per-service image columns without inferring
+// from cAdvisor's `image` label (which varies across runtimes and exposes
+// the raw digest string).
+var ApplicationInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "wandb_application_info",
+		Help: "Currently-running image for each managed W&B Application, decomposed into repository, tag, and digest.",
+	},
+	[]string{"application_name", "namespace", "image", "tag", "digest"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(ApplicationInfo)
+}
+
+// SetApplicationInfo records the running image for a single Application.
+// Existing series for the same (applicationName, namespace) pair are cleared
+// first so that an image bump doesn't leave a stale row behind in dashboards.
+func SetApplicationInfo(applicationName, namespace, repository, tag, digest string) {
+	DeleteApplicationInfo(applicationName, namespace)
+	ApplicationInfo.With(prometheus.Labels{
+		"application_name": applicationName,
+		"namespace":        namespace,
+		"image":            repository,
+		"tag":              tag,
+		"digest":           digest,
+	}).Set(1)
+}
+
+// DeleteApplicationInfo clears all series for an Application that is no
+// longer in the desired set (removed from manifest or disabled by feature
+// flag). Without this, dashboards would show stale apps as "currently
+// running" indefinitely.
+func DeleteApplicationInfo(applicationName, namespace string) {
+	ApplicationInfo.DeletePartialMatch(prometheus.Labels{
+		"application_name": applicationName,
+		"namespace":        namespace,
+	})
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func gatherApplicationInfo(t *testing.T) []*dto.Metric {
+	t.Helper()
+	out := make(chan prometheus.Metric, 64)
+	go func() {
+		ApplicationInfo.Collect(out)
+		close(out)
+	}()
+	var metrics []*dto.Metric
+	for m := range out {
+		dtoMetric := &dto.Metric{}
+		assert.NoError(t, m.Write(dtoMetric))
+		metrics = append(metrics, dtoMetric)
+	}
+	return metrics
+}
+
+func labelMap(m *dto.Metric) map[string]string {
+	out := make(map[string]string, len(m.Label))
+	for _, lp := range m.Label {
+		out[lp.GetName()] = lp.GetValue()
+	}
+	return out
+}
+
+func TestSetApplicationInfo_EmitsExpectedLabels(t *testing.T) {
+	t.Cleanup(ApplicationInfo.Reset)
+	ApplicationInfo.Reset()
+
+	SetApplicationInfo("api", "wandb", "us-docker.pkg.dev/wandb/api", "v1.0.0", "sha256:abc")
+
+	got := gatherApplicationInfo(t)
+	assert.Len(t, got, 1)
+	assert.Equal(t, 1.0, got[0].Gauge.GetValue())
+	assert.Equal(t, map[string]string{
+		"application_name": "api",
+		"namespace":        "wandb",
+		"image":            "us-docker.pkg.dev/wandb/api",
+		"tag":              "v1.0.0",
+		"digest":           "sha256:abc",
+	}, labelMap(got[0]))
+}
+
+func TestSetApplicationInfo_TagBumpClearsStaleSeries(t *testing.T) {
+	t.Cleanup(ApplicationInfo.Reset)
+	ApplicationInfo.Reset()
+
+	SetApplicationInfo("api", "wandb", "repo", "v1.0", "")
+	SetApplicationInfo("api", "wandb", "repo", "v1.1", "")
+
+	got := gatherApplicationInfo(t)
+	assert.Len(t, got, 1, "stale series from previous tag must be cleared on re-set")
+	assert.Equal(t, "v1.1", labelMap(got[0])["tag"])
+}
+
+func TestDeleteApplicationInfo_OnlyMatchesNameAndNamespace(t *testing.T) {
+	t.Cleanup(ApplicationInfo.Reset)
+	ApplicationInfo.Reset()
+
+	SetApplicationInfo("api", "wandb-a", "repo", "v1", "")
+	SetApplicationInfo("api", "wandb-b", "repo", "v1", "")
+	SetApplicationInfo("executor", "wandb-a", "repo", "v1", "")
+
+	DeleteApplicationInfo("api", "wandb-a")
+
+	got := gatherApplicationInfo(t)
+	assert.Len(t, got, 2, "delete must scope to (application_name, namespace) — leaving other apps and other namespaces intact")
+
+	remaining := make(map[string]string)
+	for _, m := range got {
+		lm := labelMap(m)
+		remaining[lm["application_name"]+"/"+lm["namespace"]] = lm["tag"]
+	}
+	assert.Contains(t, remaining, "api/wandb-b")
+	assert.Contains(t, remaining, "executor/wandb-a")
+	assert.NotContains(t, remaining, "api/wandb-a")
+}


### PR DESCRIPTION
# Summary

**JIRA:** https://coreweave.atlassian.net/browse/ONPREM-198

1. Wires TelemetryRuntimeConfig.OTel.SecretName into the env-var inject path via a new bindTelemetrySecretName helper, and makes resolveEnvvars return a loud error when a telemetry source still has no name after binding. Before this, env vars referencing the telemetry secret were silently dropped from gorilla pods. There does exists a secret `wandb-otel-connection` is stored in `TelemetryRuntimeConfig.OTel.SecretName`. 
2. Adds a new internal/metrics package that registers a `wandb_application_info{application_name,namespace,image,tag,digest}` gauge on the controller-runtime registry. Fixes the operator's `VMServiceScrape` and adds `honorLabels: true` so the metric's intrinsic namespace label isn't overwritten by the operator pod's namespace. 
3.  A new MIP panel ("Slowest Storage Operations") uses `histogram_quantile(0.95, ...)` over the new metric to surface per-span p95 latency for  parquet/filestream/SQL operations
4. Adds the OTel `spanmetrics` connector to the Collector config, wired as a sink in the traces pipeline and a source in the metrics pipeline; it derives `traces_spanmetrics_calls_total` and  `traces_spanmetrics_duration_milliseconds_`* from inbound traces.
5. Tiltfile change extends Operator-Chart-Deps watch list to include deploy/telemetry/templates and deploy/telemetry/dashboards
6. Adds an opt-in `VMServiceScrape` (scrape.kubeStateMetrics: true) that discovers `kube-state-metrics` across all namespaces

# Test Summary

Spun up a cluster and tilt up:

```bash
./hack/scripts/setup_kind.sh ; tilt up
```

Sample of dashboard changes:

### Field Investigation Dashboard

**Splits Images**
<img width="1426" height="475" alt="Screenshot 2026-05-20 at 10 44 17 AM" src="https://github.com/user-attachments/assets/6c26463f-fa3f-4835-9862-52ef6ecf375e" />

**p50, p95, p99 along with mean, min, max, and sum like DataDog**
<img width="923" height="740" alt="Screenshot 2026-05-20 at 10 47 00 AM" src="https://github.com/user-attachments/assets/621d24dd-9a11-492f-ab27-a3fb3fad46ae" />

### Managed Install Performance Dashboard

**KSM + Percentage Metrics**
<img width="933" height="740" alt="Screenshot 2026-05-20 at 10 48 00 AM" src="https://github.com/user-attachments/assets/198456d0-9e29-428f-946d-fe277f065499" />

