### PR TITLE
feat(operator): Adds security context to app pods)

### DIFF
--- a/internal/controller/reconciler/pods.go
+++ b/internal/controller/reconciler/pods.go
@@ -10,8 +10,33 @@ import (
 	serverManifest "github.com/wandb/operator/pkg/wandb/manifest"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const appWorkloadCapabilityAll v1.Capability = "ALL"
+
+func resolvePodSecurityContext() *v1.PodSecurityContext {
+	return &v1.PodSecurityContext{
+		SeccompProfile: resolveRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func resolveContainerSecurityContext() *v1.SecurityContext {
+	return &v1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{appWorkloadCapabilityAll},
+		},
+		SeccompProfile: resolveRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func resolveRuntimeDefaultSeccompProfile() *v1.SeccompProfile {
+	return &v1.SeccompProfile{
+		Type: v1.SeccompProfileTypeRuntimeDefault,
+	}
+}
 
 func resolveInitContainers(app serverManifest.Application, envVars []v1.EnvVar, volumeMounts []v1.VolumeMount) []v1.Container {
 	initContainers := []v1.Container{}
@@ -22,12 +47,13 @@ func resolveInitContainers(app serverManifest.Application, envVars []v1.EnvVar, 
 				continue
 			}
 			initContainer := v1.Container{
-				Name:         initContainerSpec.Name,
-				Image:        initContainerSpec.Image.GetImage(),
-				Env:          envVars,
-				Args:         initContainerSpec.Args,
-				Command:      initContainerSpec.Command,
-				VolumeMounts: volumeMounts,
+				Name:            initContainerSpec.Name,
+				Image:           initContainerSpec.Image.GetImage(),
+				Env:             envVars,
+				Args:            initContainerSpec.Args,
+				Command:         initContainerSpec.Command,
+				VolumeMounts:    volumeMounts,
+				SecurityContext: resolveContainerSecurityContext(),
 			}
 			initContainers = append(initContainers, initContainer)
 		}
@@ -66,13 +92,14 @@ func resolveContainers(app serverManifest.Application, wandb *v2.WeightsAndBiase
 			}
 
 			c := v1.Container{
-				Name:         container.Name,
-				Image:        img,
-				Env:          envVars,
-				Args:         args,
-				Command:      cmd,
-				Ports:        containerPorts,
-				VolumeMounts: volumeMounts,
+				Name:            container.Name,
+				Image:           img,
+				Env:             envVars,
+				Args:            args,
+				Command:         cmd,
+				Ports:           containerPorts,
+				VolumeMounts:    volumeMounts,
+				SecurityContext: resolveContainerSecurityContext(),
 			}
 
 			if resources := ResolveResources(app, wandb, container.Resources); resources != nil {
@@ -110,12 +137,13 @@ func resolveContainers(app serverManifest.Application, wandb *v2.WeightsAndBiase
 	} else {
 		// Backward-compatible single-container behavior
 		c := v1.Container{
-			Name:         app.Name,
-			Image:        app.Image.GetImage(),
-			Env:          envVars,
-			Args:         app.Args,
-			Command:      app.Command,
-			VolumeMounts: volumeMounts,
+			Name:            app.Name,
+			Image:           app.Image.GetImage(),
+			Env:             envVars,
+			Args:            app.Args,
+			Command:         app.Command,
+			VolumeMounts:    volumeMounts,
+			SecurityContext: resolveContainerSecurityContext(),
 		}
 
 		if resources := ResolveResources(app, wandb, nil); resources != nil {

--- a/internal/controller/reconciler/reconcile_v2.go
+++ b/internal/controller/reconciler/reconcile_v2.go
@@ -566,6 +566,7 @@ func reconcileApplications(
 		// across updates (e.g., duplicate "files-inline" volume names).
 		application.Spec.PodTemplate.Spec.Volumes = volumes
 		application.Spec.PodTemplate.Spec.InitContainers = initContainers
+		application.Spec.PodTemplate.Spec.SecurityContext = resolvePodSecurityContext()
 		application.Spec.PodTemplate.Spec.Affinity = wandb.Spec.Affinity
 		application.Spec.PodTemplate.Spec.Tolerations = *wandb.Spec.Tolerations
 


### PR DESCRIPTION
App containers and init containers now get allowPrivilegeEscalation: false, capabilities.drop: ["ALL"], and seccompProfile: RuntimeDefault.

The generated Application pod template also gets pod-level RuntimeDefault

TODO: we can't yet add `readOnlyRootFilesystem` for app pods until they get fixed upstream