### PR TITLE
feat:Colander/Filer-update

### DIFF
--- a/config/certmanager/seaweed-issuer.yaml
+++ b/config/certmanager/seaweed-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: seaweedfs-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/deploy/operator/templates/certificates.yaml
+++ b/deploy/operator/templates/certificates.yaml
@@ -21,4 +21,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-seaweedfs-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
 {{- end }}

--- a/internal/controller/infra/managed/objectstore/seaweedfs/policy.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/policy.go
@@ -1,0 +1,87 @@
+package seaweedfs
+
+import (
+	"fmt"
+
+	apiv2 "github.com/wandb/operator/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	filerHTTPPort = 8888
+	filerGRPCPort = 18888
+)
+
+// ToFilerNetworkPolicy generates a NetworkPolicy that restricts ingress to the
+// Seaweed Filer pods so only sibling Seaweed components (S3 gateway, Master,
+// Volume, and other Filer replicas) can reach them. The Filer's HTTP API on
+// port 8888 is unauthenticated by default; this policy keeps it off-limits to
+// arbitrary in-cluster traffic.
+func ToFilerNetworkPolicy(
+	wandb *apiv2.WeightsAndBiases,
+	scheme *runtime.Scheme,
+) (*networkingv1.NetworkPolicy, error) {
+	infraSpec := wandb.Spec.ObjectStore.ManagedObjectStore
+	if infraSpec == nil {
+		return nil, nil
+	}
+
+	seaweedName := SeaweedName(infraSpec.Name)
+	policyName := fmt.Sprintf("%s-filer-restrict", seaweedName)
+	tcp := corev1.ProtocolTCP
+	httpPort := intstr.FromInt(filerHTTPPort)
+	grpcPort := intstr.FromInt(filerGRPCPort)
+
+	componentPeer := func(component string) networkingv1.NetworkPolicyPeer {
+		return networkingv1.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/instance":  seaweedName,
+					"app.kubernetes.io/component": component,
+				},
+			},
+		}
+	}
+
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: infraSpec.Namespace,
+			Labels:    BuildWandbObjectStoreLabels(wandb),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/instance":  seaweedName,
+					"app.kubernetes.io/component": "filer",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						componentPeer("s3"),
+						componentPeer("master"),
+						componentPeer("volume"),
+						componentPeer("filer"),
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &httpPort},
+						{Protocol: &tcp, Port: &grpcPort},
+					},
+				},
+			},
+		},
+	}
+
+	if err := ctrl.SetControllerReference(wandb, policy, scheme); err != nil {
+		return nil, fmt.Errorf("failed to set owner reference on Filer NetworkPolicy: %w", err)
+	}
+
+	return policy, nil
+}

--- a/internal/controller/infra/managed/objectstore/seaweedfs/spec.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/spec.go
@@ -82,6 +82,10 @@ func ToObjectStoreVendorSpec(
 			Image: SeaweedImage,
 			TLS: &seaweedv1.TLSSpec{
 				Enabled: infraSpec.SeaweedObjectStoreSpec.TlsEnabled,
+				IssuerRef: &seaweedv1.TLSIssuerRef{
+					Name:  "wandb-operator-seaweedfs-issuer",
+					Kind:  "Issuer",
+				},
 			},
 			Master: &seaweedv1.MasterSpec{
 				Replicas:           1,

--- a/internal/controller/infra/managed/objectstore/seaweedfs/spec_test.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/spec_test.go
@@ -32,6 +32,10 @@ var _ = Describe("SeaweedFS vendor specs", func() {
 		expectSeaweedWritableMount(seaweed.Spec.Volume.VolumeMounts)
 		expectSeaweedWritableVolume(seaweed.Spec.Filer.Volumes)
 		expectSeaweedWritableMount(seaweed.Spec.Filer.VolumeMounts)
+		Expect(seaweed.Spec.TLS).NotTo(BeNil())
+		Expect(seaweed.Spec.TLS.IssuerRef).NotTo(BeNil())
+		Expect(seaweed.Spec.TLS.IssuerRef.Name).To(Equal("wandb-operator-seaweedfs-issuer"))
+		Expect(seaweed.Spec.TLS.IssuerRef.Kind).To(Equal("Issuer"))
 	})
 
 	It("keeps the filer writable data path explicit", func() {

--- a/internal/controller/infra/managed/objectstore/seaweedfs/write.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/write.go
@@ -63,7 +63,7 @@ func WriteState(
 
 	// Upsert the Filer NetworkPolicy that restricts the unauthenticated HTTP
 	// port to sibling Seaweed components. Must exist when (or before) the
-	// Filer pod comes up, so do this before the main CR upsert.
+	// Filer pod comes up
 	if policy != nil {
 		actualPolicy := &networkingv1.NetworkPolicy{}
 		policyNsName := types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}

--- a/internal/controller/infra/managed/objectstore/seaweedfs/write.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/write.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wandb/operator/internal/logx"
 	seaweedv1 "github.com/wandb/operator/pkg/vendored/seaweedfs-operator/seaweed.seaweedfs.com/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +31,7 @@ func WriteState(
 	desiredCr *seaweedv1.Seaweed,
 	envConfig SeaweedS3Config,
 	wandbOwner client.Object,
+	policy *networkingv1.NetworkPolicy,
 ) ([]metav1.Condition, *apiv2.ObjectStoreConnection) {
 	ctx, _ = logx.WithSlog(ctx, logx.ObjectStore)
 	var actual = &seaweedv1.Seaweed{}
@@ -58,6 +60,33 @@ func WriteState(
 	}
 
 	result := make([]metav1.Condition, 0)
+
+	// Upsert the Filer NetworkPolicy that restricts the unauthenticated HTTP
+	// port to sibling Seaweed components. Must exist when (or before) the
+	// Filer pod comes up, so do this before the main CR upsert.
+	if policy != nil {
+		actualPolicy := &networkingv1.NetworkPolicy{}
+		policyNsName := types.NamespacedName{Name: policy.Name, Namespace: policy.Namespace}
+		policyFound, policyErr := common.GetResource(ctx, kubeClient, policyNsName, "NetworkPolicy", actualPolicy)
+		if policyErr != nil {
+			result = append(result, metav1.Condition{
+				Type:   common.ReconciledType,
+				Status: metav1.ConditionFalse,
+				Reason: common.ApiErrorReason,
+			})
+		} else {
+			if !policyFound {
+				actualPolicy = nil
+			}
+			if _, policyErr := common.CrudResource(ctx, kubeClient, policy, actualPolicy); policyErr != nil {
+				result = append(result, metav1.Condition{
+					Type:   common.ReconciledType,
+					Status: metav1.ConditionFalse,
+					Reason: common.ApiErrorReason,
+				})
+			}
+		}
+	}
 
 	action, err := common.CrudResource(ctx, kubeClient, desiredCr, actual)
 	if err != nil {

--- a/internal/controller/reconciler/objectstore.go
+++ b/internal/controller/reconciler/objectstore.go
@@ -150,7 +150,19 @@ func managedObjectStoreWriteState(
 		}, nil
 	}
 
-	conditions, connection := seaweedfs.WriteState(ctx, client, specNamespacedName, desiredCr, desiredConfig, wandb)
+	desiredFilerPolicy, err := seaweedfs.ToFilerNetworkPolicy(wandb, client.Scheme())
+	if err != nil {
+		log.Error(err, "failed to build Filer NetworkPolicy")
+		return []metav1.Condition{
+			{
+				Type:   common.ReconciledType,
+				Status: metav1.ConditionFalse,
+				Reason: common.ControllerErrorReason,
+			},
+		}, nil
+	}
+
+	conditions, connection := seaweedfs.WriteState(ctx, client, specNamespacedName, desiredCr, desiredConfig, wandb, desiredFilerPolicy)
 	return conditions, connection
 }
 


### PR DESCRIPTION
Before
```
kubectl run curl-test --rm -it --image=curlimages/curl --restart=Never -n wandb -- curl -m 5 -v http://wandb-seaweedfs-filer:8888
* Host wandb-seaweedfs-filer:8888 was resolved.
* IPv6: (none)
* IPv4: 10.96.11.71
*   Trying 10.96.11.71:8888...
* Established connection to wandb-seaweedfs-filer (10.96.11.71 port 8888) from 10.244.0.122 port 42098 
* using HTTP/1.x
> GET / HTTP/1.1
> Host: wandb-seaweedfs-filer:8888
> User-Agent: curl/8.20.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Server: SeaweedFS 30GB 4.30
< X-Amz-Request-Id: 18B52375394909AD67ED9D9E
< Date: Tue, 02 Jun 2026 02:43:34 GMT
< Content-Type: text/html; charset=utf-8
< Transfer-Encoding: chunked
< 
<!DOCTYPE html>
<html>
<head>
    <title>SeaweedFS Filer 30GB 4.30 34be9170f</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <link rel="stylesheet" href="/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
    <style>
        body {
            padding-bottom: 128px;
        }
.... rest of file
```

After
```
kubectl run curl-test --rm -it --image=curlimages/curl --restart=Never -n wandb -- curl -m 5 -v http://wandb-seaweedfs-filer:8888
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
* Connection timed out after 5001 milliseconds
* closing connection #0
curl: (28) Connection timed out after 5001 milliseconds
pod "curl-test" deleted from wandb namespace
pod wandb/curl-test terminated (Error)
```