### PR TITLE
feat(operator): Adds security context to app pods

### DIFF
--- a/deploy/operator/profiles/openshift.yaml
+++ b/deploy/operator/profiles/openshift.yaml
@@ -1,5 +1,5 @@
 wandb-operator:
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
     runAsUser: null
     runAsGroup: null
@@ -13,18 +13,33 @@ wandb-operator:
   volumes:
     - name: server-manifest
       emptyDir: {}
+    - name: helm-home
+      emptyDir: {}
     - name: serving-certs
       secret:
         secretName: '{{ .Release.Name }}-serving-cert'
 
   containers:
     operator:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: null
+        runAsGroup: null
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       env:
         OPENSHIFT:
           value: "true"
       volumeMounts:
         - mountPath: /tmp/server-manifest
           name: server-manifest
+        - mountPath: /helm
+          name: helm-home
         - mountPath: /tmp/wandb-operator/serving-certs
           name: serving-certs
           readOnly: true

--- a/deploy/operator/profiles/openshift.yaml
+++ b/deploy/operator/profiles/openshift.yaml
@@ -22,16 +22,11 @@ wandb-operator:
   containers:
     operator:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: null
-        runAsGroup: null
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
         capabilities:
           drop:
             - "ALL"
-        seccompProfile:
-          type: RuntimeDefault
       env:
         OPENSHIFT:
           value: "true"

--- a/deploy/operator/profiles/openshift.yaml
+++ b/deploy/operator/profiles/openshift.yaml
@@ -1,43 +1,15 @@
 wandb-operator:
   podSecurityContext:
-    runAsNonRoot: true
     runAsUser: null
     runAsGroup: null
     fsGroup: null
     fsGroupChangePolicy: null
-    seccompProfile:
-      type: RuntimeDefault
-
-  # readOnlyRootFilesystem requires writable mounts where the operator
-  # writes manifests and reads serving certs.
-  volumes:
-    - name: server-manifest
-      emptyDir: {}
-    - name: helm-home
-      emptyDir: {}
-    - name: serving-certs
-      secret:
-        secretName: '{{ .Release.Name }}-serving-cert'
 
   containers:
     operator:
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        capabilities:
-          drop:
-            - "ALL"
       env:
         OPENSHIFT:
           value: "true"
-      volumeMounts:
-        - mountPath: /tmp/server-manifest
-          name: server-manifest
-        - mountPath: /helm
-          name: helm-home
-        - mountPath: /tmp/wandb-operator/serving-certs
-          name: serving-certs
-          readOnly: true
 
 grafana-operator:
   isOpenShift: true

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -61,16 +61,11 @@ wandb-operator:
               name: '{{ .Release.Name }}-telemetry-config'
               key: TELEMETRY_OTEL_RESOURCE_ATTRIBUTES
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
         capabilities:
           drop:
             - "ALL"
-        seccompProfile:
-          type: RuntimeDefault
       livenessProbe:
         httpGet:
           path: /healthz
@@ -96,8 +91,6 @@ wandb-operator:
         - mountPath: /tmp/wandb-operator/serving-certs
           name: serving-certs
           readOnly: true
-        - mountPath: /helm
-          name: helm-home
 
   service:
     enabled: true
@@ -125,8 +118,6 @@ wandb-operator:
     - name: serving-certs
       secret:
         secretName: '{{ .Release.Name }}-serving-cert'
-    - name: helm-home
-      emptyDir: {}
 
   operators:
     application: true
@@ -152,16 +143,11 @@ redis-operator:
     seccompProfile:
       type: RuntimeDefault
   securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    runAsGroup: 1000
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     capabilities:
       drop:
         - "ALL"
-    seccompProfile:
-      type: RuntimeDefault
 
 strimzi-kafka-operator:
   enabled: true
@@ -175,16 +161,11 @@ strimzi-kafka-operator:
     seccompProfile:
       type: RuntimeDefault
   securityContext:
-    runAsNonRoot: true
-    runAsUser: 1001
-    runAsGroup: 1001
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     capabilities:
       drop:
         - "ALL"
-    seccompProfile:
-      type: RuntimeDefault
   extraEnvs:
     - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
       value: restricted
@@ -240,28 +221,18 @@ altinity-clickhouse-operator:
       type: RuntimeDefault
   operator:
     containerSecurityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
-      runAsGroup: 1000
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
         drop:
           - "ALL"
-      seccompProfile:
-        type: RuntimeDefault
   metrics:
     containerSecurityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
-      runAsGroup: 1000
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
         drop:
           - "ALL"
-      seccompProfile:
-        type: RuntimeDefault
   configs:
     files:
       config.yaml:

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -126,10 +126,51 @@ cert-manager:
 
 redis-operator:
   install: true
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - "ALL"
+    seccompProfile:
+      type: RuntimeDefault
 
 strimzi-kafka-operator:
   install: true
   watchAnyNamespace: true
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    fsGroup: 1001
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - "ALL"
+    seccompProfile:
+      type: RuntimeDefault
+  extraEnvs:
+    - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+      value: restricted
 
 seaweedfs-operator:
   install: true
@@ -146,6 +187,38 @@ altinity-clickhouse-operator:
         cpu: 100m
         memory: 128Mi
   install: true
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  operator:
+    containerSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - "ALL"
+      seccompProfile:
+        type: RuntimeDefault
+  metrics:
+    containerSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - "ALL"
+      seccompProfile:
+        type: RuntimeDefault
   configs:
     files:
       config.yaml:

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -58,10 +58,16 @@ wandb-operator:
               name: '{{ .Release.Name }}-telemetry-config'
               key: TELEMETRY_OTEL_RESOURCE_ATTRIBUTES
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
         allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
         capabilities:
           drop:
             - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       livenessProbe:
         httpGet:
           path: /healthz
@@ -85,6 +91,10 @@ wandb-operator:
         - mountPath: /tmp/wandb-operator/serving-certs
           name: serving-certs
           readOnly: true
+        - mountPath: /tmp/server-manifest
+          name: server-manifest
+        - mountPath: /helm
+          name: helm-home
 
   service:
     enabled: true
@@ -98,14 +108,22 @@ wandb-operator:
         protocol: TCP
         targetPort: 8443
   replicaCount: 1
-  securityContext:
-    runAsNonRoot: false
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    fsGroupChangePolicy: OnRootMismatch
     seccompProfile:
       type: RuntimeDefault
   volumes:
     - name: serving-certs
       secret:
         secretName: '{{ .Release.Name }}-serving-cert'
+    - name: server-manifest
+      emptyDir: {}
+    - name: helm-home
+      emptyDir: {}
 
   operators:
     application: true

--- a/internal/controller/reconciler/pods.go
+++ b/internal/controller/reconciler/pods.go
@@ -10,8 +10,33 @@ import (
 	serverManifest "github.com/wandb/operator/pkg/wandb/manifest"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const appWorkloadCapabilityAll v1.Capability = "ALL"
+
+func resolvePodSecurityContext() *v1.PodSecurityContext {
+	return &v1.PodSecurityContext{
+		SeccompProfile: resolveRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func resolveContainerSecurityContext() *v1.SecurityContext {
+	return &v1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{appWorkloadCapabilityAll},
+		},
+		SeccompProfile: resolveRuntimeDefaultSeccompProfile(),
+	}
+}
+
+func resolveRuntimeDefaultSeccompProfile() *v1.SeccompProfile {
+	return &v1.SeccompProfile{
+		Type: v1.SeccompProfileTypeRuntimeDefault,
+	}
+}
 
 func resolveInitContainers(app serverManifest.Application, envVars []v1.EnvVar, volumeMounts []v1.VolumeMount) []v1.Container {
 	initContainers := []v1.Container{}
@@ -22,12 +47,13 @@ func resolveInitContainers(app serverManifest.Application, envVars []v1.EnvVar, 
 				continue
 			}
 			initContainer := v1.Container{
-				Name:         initContainerSpec.Name,
-				Image:        initContainerSpec.Image.GetImage(),
-				Env:          envVars,
-				Args:         initContainerSpec.Args,
-				Command:      initContainerSpec.Command,
-				VolumeMounts: volumeMounts,
+				Name:            initContainerSpec.Name,
+				Image:           initContainerSpec.Image.GetImage(),
+				Env:             envVars,
+				Args:            initContainerSpec.Args,
+				Command:         initContainerSpec.Command,
+				VolumeMounts:    volumeMounts,
+				SecurityContext: resolveContainerSecurityContext(),
 			}
 			initContainers = append(initContainers, initContainer)
 		}
@@ -66,13 +92,14 @@ func resolveContainers(app serverManifest.Application, wandb *v2.WeightsAndBiase
 			}
 
 			c := v1.Container{
-				Name:         container.Name,
-				Image:        img,
-				Env:          envVars,
-				Args:         args,
-				Command:      cmd,
-				Ports:        containerPorts,
-				VolumeMounts: volumeMounts,
+				Name:            container.Name,
+				Image:           img,
+				Env:             envVars,
+				Args:            args,
+				Command:         cmd,
+				Ports:           containerPorts,
+				VolumeMounts:    volumeMounts,
+				SecurityContext: resolveContainerSecurityContext(),
 			}
 
 			if resources := ResolveResources(app, wandb, container.Resources); resources != nil {
@@ -110,12 +137,13 @@ func resolveContainers(app serverManifest.Application, wandb *v2.WeightsAndBiase
 	} else {
 		// Backward-compatible single-container behavior
 		c := v1.Container{
-			Name:         app.Name,
-			Image:        app.Image.GetImage(),
-			Env:          envVars,
-			Args:         app.Args,
-			Command:      app.Command,
-			VolumeMounts: volumeMounts,
+			Name:            app.Name,
+			Image:           app.Image.GetImage(),
+			Env:             envVars,
+			Args:            app.Args,
+			Command:         app.Command,
+			VolumeMounts:    volumeMounts,
+			SecurityContext: resolveContainerSecurityContext(),
 		}
 
 		if resources := ResolveResources(app, wandb, nil); resources != nil {

--- a/internal/controller/reconciler/reconcile_v2.go
+++ b/internal/controller/reconciler/reconcile_v2.go
@@ -566,6 +566,7 @@ func reconcileApplications(
 		// across updates (e.g., duplicate "files-inline" volume names).
 		application.Spec.PodTemplate.Spec.Volumes = volumes
 		application.Spec.PodTemplate.Spec.InitContainers = initContainers
+		application.Spec.PodTemplate.Spec.SecurityContext = resolvePodSecurityContext()
 		application.Spec.PodTemplate.Spec.Affinity = wandb.Spec.Affinity
 		application.Spec.PodTemplate.Spec.Tolerations = *wandb.Spec.Tolerations
 


### PR DESCRIPTION
Merges 3 existing PRs

- Hardens operator chart runtime defaults #190 
- Adds security contexts for Redis, Clickhouse, and Kafka pods #191 
- App containers and init containers now get allowPrivilegeEscalation: false, capabilities.drop: ["ALL"], and seccompProfile: RuntimeDefault. The generated Application pod template also gets pod-level RuntimeDefault #192 
