### PR TITLE
fix: Detect unavailable writable SeaweedFS storage

### DIFF
--- a/internal/controller/infra/managed/objectstore/seaweedfs/read.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/read.go
@@ -2,6 +2,13 @@ package seaweedfs
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
 
 	ctrlcommon "github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/logx"
@@ -10,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const seaweedAllocationProbeTimeout = 5 * time.Second
 
 func ReadState(
 	ctx context.Context,
@@ -65,10 +74,99 @@ func ReadState(
 	}
 
 	if actualResource != nil {
-		conditions = append(conditions, computeSeaweedReportedReadyCondition(ctx, actualResource)...)
+		readyConditions := computeSeaweedReportedReadyCondition(ctx, actualResource)
+		conditions = append(conditions, readyConditions...)
+		if readyConditions[0].Status == metav1.ConditionTrue {
+			conditions = append(conditions, computeSeaweedWritableCondition(ctx, actualResource))
+		}
 	}
 	log.Debug("read", "actualResource", actualResource, "rule", onDeleteRule.Policy)
 	return conditions
+}
+
+type seaweedAssignResponse struct {
+	FID   string `json:"fid"`
+	Error string `json:"error"`
+}
+
+func computeSeaweedWritableCondition(ctx context.Context, cr *seaweedv1.Seaweed) metav1.Condition {
+	scheme := "http"
+	transport := http.DefaultTransport
+	if cr.Spec.TLS != nil && cr.Spec.TLS.Enabled {
+		scheme = "https"
+		tlsTransport := http.DefaultTransport.(*http.Transport).Clone()
+		// The Seaweed operator generates an internal certificate whose CA is not
+		// mounted into this controller. The request never leaves the cluster DNS
+		// name and only verifies that the master can allocate writable storage.
+		tlsTransport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} // #nosec G402
+		transport = tlsTransport
+	}
+
+	endpoint := url.URL{
+		Scheme: scheme,
+		Host: fmt.Sprintf(
+			"%s-master.%s.svc.cluster.local:%d",
+			cr.Name,
+			cr.Namespace,
+			seaweedv1.MasterHTTPPort,
+		),
+		Path: "/dir/assign",
+	}
+	query := endpoint.Query()
+	query.Set("count", "1")
+	if cr.Spec.Master != nil && cr.Spec.Master.DefaultReplication != nil {
+		query.Set("replication", *cr.Spec.Master.DefaultReplication)
+	}
+	endpoint.RawQuery = query.Encode()
+
+	return probeSeaweedAllocation(ctx, &http.Client{Transport: transport, Timeout: seaweedAllocationProbeTimeout}, endpoint.String())
+}
+
+func probeSeaweedAllocation(ctx context.Context, client *http.Client, endpoint string) metav1.Condition {
+	condition := metav1.Condition{
+		Type:   SeaweedWritableType,
+		Status: metav1.ConditionFalse,
+		Reason: "AllocationFailed",
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		condition.Message = err.Error()
+		return condition
+	}
+	response, err := client.Do(req)
+	if err != nil {
+		condition.Message = err.Error()
+		return condition
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	if err != nil {
+		condition.Message = err.Error()
+		return condition
+	}
+	var assign seaweedAssignResponse
+	if err := json.Unmarshal(body, &assign); err != nil {
+		condition.Message = fmt.Sprintf("invalid allocation response: %v", err)
+		return condition
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		condition.Message = fmt.Sprintf("allocation returned HTTP %d: %s", response.StatusCode, assign.Error)
+		return condition
+	}
+	if assign.Error != "" {
+		condition.Message = assign.Error
+		return condition
+	}
+	if assign.FID == "" {
+		condition.Message = "allocation response did not include a file ID"
+		return condition
+	}
+
+	condition.Status = metav1.ConditionTrue
+	condition.Reason = "AllocationSucceeded"
+	return condition
 }
 
 func computeSeaweedReportedReadyCondition(_ context.Context, cr *seaweedv1.Seaweed) []metav1.Condition {

--- a/internal/controller/infra/managed/objectstore/seaweedfs/read_test.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/read_test.go
@@ -1,0 +1,56 @@
+package seaweedfs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("SeaweedFS writable storage probe", func() {
+	It("reports writable storage after an allocation succeeds", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			Expect(request.URL.Path).To(Equal("/dir/assign"))
+			_, err := response.Write([]byte(`{"fid":"3,01637037d6","url":"volume:8444","count":1}`))
+			Expect(err).NotTo(HaveOccurred())
+		}))
+		DeferCleanup(server.Close)
+
+		condition := probeSeaweedAllocation(context.Background(), server.Client(), server.URL+"/dir/assign")
+
+		Expect(condition.Type).To(Equal(SeaweedWritableType))
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal("AllocationSucceeded"))
+	})
+
+	It("reports allocation errors as not writable", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			response.WriteHeader(http.StatusInternalServerError)
+			_, err := response.Write([]byte(`{"error":"No writable volumes and no free volumes left"}`))
+			Expect(err).NotTo(HaveOccurred())
+		}))
+		DeferCleanup(server.Close)
+
+		condition := probeSeaweedAllocation(context.Background(), server.Client(), server.URL)
+
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal("AllocationFailed"))
+		Expect(condition.Message).To(ContainSubstring("No writable volumes"))
+	})
+
+	It("rejects successful responses without an allocation", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			_, err := response.Write([]byte(`{"count":0}`))
+			Expect(err).NotTo(HaveOccurred())
+		}))
+		DeferCleanup(server.Close)
+
+		condition := probeSeaweedAllocation(context.Background(), server.Client(), server.URL)
+
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Message).To(ContainSubstring("file ID"))
+	})
+})

--- a/internal/controller/infra/managed/objectstore/seaweedfs/spec.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/spec.go
@@ -43,7 +43,23 @@ const (
 	seaweedMasterMetricsPort int32 = 9091
 	seaweedVolumeMetricsPort int32 = 9092
 	seaweedFilerMetricsPort  int32 = 9093
+	seaweedVolumeSizeLimitMB int64 = 1024
 )
+
+func volumeLayout(storageQuantity resource.Quantity) (int32, int32) {
+	storageMB := storageQuantity.Value() / (1024 * 1024)
+	volumeSizeMB := min(seaweedVolumeSizeLimitMB, storageMB/2)
+	if volumeSizeMB < 1 {
+		volumeSizeMB = 1
+	}
+
+	maxVolumeCount := storageMB/volumeSizeMB - 1
+	if maxVolumeCount < 1 {
+		maxVolumeCount = 1
+	}
+
+	return int32(volumeSizeMB), int32(maxVolumeCount)
+}
 
 func seaweedWritableVolumes() []corev1.Volume {
 	return []corev1.Volume{
@@ -86,7 +102,7 @@ func ToObjectStoreVendorSpec(
 		replication = "001"
 	}
 
-	volumeSizeLimitMB := int32(storageQuantity.Value() / (1024 * 1024))
+	volumeSizeLimitMB, maxVolumeCount := volumeLayout(storageQuantity)
 
 	labels := BuildWandbObjectStoreLabels(wandb)
 	labels["app"] = SeaweedName(specName)
@@ -110,15 +126,18 @@ func ToObjectStoreVendorSpec(
 				ComponentSpec: seaweedv1.ComponentSpec{
 					Volumes:      seaweedWritableVolumes(),
 					VolumeMounts: seaweedWritableVolumeMounts(),
+					ExtraArgs:    []string{"-ip.bind=0.0.0.0"},
 				},
 			},
 			Volume: &seaweedv1.VolumeSpec{
 				Replicas: infraSpec.Replicas,
 				VolumeServerConfig: seaweedv1.VolumeServerConfig{
-					MetricsPort: ptr.To(seaweedVolumeMetricsPort),
+					MetricsPort:     ptr.To(seaweedVolumeMetricsPort),
+					MaxVolumeCounts: ptr.To(maxVolumeCount),
 					ComponentSpec: seaweedv1.ComponentSpec{
 						Volumes:      seaweedWritableVolumes(),
 						VolumeMounts: seaweedWritableVolumeMounts(),
+						ExtraArgs:    []string{"-ip.bind=0.0.0.0"},
 					},
 					ResourceRequirements: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -158,6 +177,7 @@ func ToObjectStoreVendorSpec(
 				ComponentSpec: seaweedv1.ComponentSpec{
 					Volumes:      seaweedWritableVolumes(),
 					VolumeMounts: seaweedWritableVolumeMounts(),
+					ExtraArgs:    []string{"-ip.bind=0.0.0.0"},
 				},
 				Persistence: &seaweedv1.PersistenceSpec{
 					Enabled:   true,

--- a/internal/controller/infra/managed/objectstore/seaweedfs/spec_test.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/spec_test.go
@@ -33,6 +33,9 @@ var _ = Describe("SeaweedFS vendor specs", func() {
 		expectSeaweedWritableMount(seaweed.Spec.Volume.VolumeMounts)
 		expectSeaweedWritableVolume(seaweed.Spec.Filer.Volumes)
 		expectSeaweedWritableMount(seaweed.Spec.Filer.VolumeMounts)
+		Expect(seaweed.Spec.Master.ExtraArgs).To(ContainElement("-ip.bind=0.0.0.0"))
+		Expect(seaweed.Spec.Volume.ExtraArgs).To(ContainElement("-ip.bind=0.0.0.0"))
+		Expect(seaweed.Spec.Filer.ExtraArgs).To(ContainElement("-ip.bind=0.0.0.0"))
 	})
 
 	It("retargets the image to spec.global.imageRegistry when set", func() {
@@ -74,6 +77,29 @@ var _ = Describe("SeaweedFS vendor specs", func() {
 		Expect(seaweed).NotTo(BeNil())
 		Expect(seaweed.Spec.Volume.ResourceRequirements.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("500m")))
 	})
+
+	It("reserves storage headroom for writable volumes", func() {
+		wandb := seaweedWandb()
+		seaweed, err := ToObjectStoreVendorSpec(context.Background(), wandb, wandb.Spec.ObjectStore[apiv2.DefaultInstanceName].ManagedObjectStore, seaweedScheme(), manifest.Manifest{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(seaweed.Spec.Master.VolumeSizeLimitMB).NotTo(BeNil())
+		Expect(*seaweed.Spec.Master.VolumeSizeLimitMB).To(Equal(int32(1024)))
+		Expect(seaweed.Spec.Volume.MaxVolumeCounts).NotTo(BeNil())
+		Expect(*seaweed.Spec.Volume.MaxVolumeCounts).To(Equal(int32(9)))
+	})
+
+	DescribeTable("computes a writable volume layout",
+		func(storage string, expectedSizeMB, expectedMaxVolumes int32) {
+			size, count := volumeLayout(resource.MustParse(storage))
+			Expect(size).To(Equal(expectedSizeMB))
+			Expect(count).To(Equal(expectedMaxVolumes))
+		},
+		Entry("a development volume", "10Gi", int32(1024), int32(9)),
+		Entry("the upstream minimum example", "2Gi", int32(1024), int32(1)),
+		Entry("a sub-gibibyte volume", "512Mi", int32(256), int32(1)),
+		Entry("a large volume", "1Ti", int32(1024), int32(1023)),
+	)
 
 	It("pins s3 gateway signature verification to the in-cluster endpoint", func() {
 		wandb := seaweedWandb()

--- a/internal/controller/infra/managed/objectstore/seaweedfs/status.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/status.go
@@ -17,6 +17,7 @@ const (
 	SeaweedCustomResourceType = "SeaweedCustomResource"
 	SeaweedConnectionInfoType = "SeaweedConnectionInfo"
 	SeaweedReportedReadyType  = "SeaweedReportedReady"
+	SeaweedWritableType       = "SeaweedWritable"
 )
 
 func ComputeStatus(
@@ -70,6 +71,13 @@ func applyDefaultConditions(conditions []metav1.Condition) []metav1.Condition {
 			Reason: common.NoResourceReason,
 		})
 	}
+	if !common.ContainsType(conditions, SeaweedWritableType) {
+		conditions = append(conditions, metav1.Condition{
+			Type:   SeaweedWritableType,
+			Status: metav1.ConditionUnknown,
+			Reason: common.NoResourceReason,
+		})
+	}
 
 	return conditions
 }
@@ -88,6 +96,7 @@ func inferInfraState(
 	impliedStates = inferStateFromCondition(ctx, SeaweedCustomResourceType, impliedStates, conditions)
 	impliedStates = inferStateFromCondition(ctx, SeaweedConnectionInfoType, impliedStates, conditions)
 	impliedStates = inferStateFromCondition(ctx, SeaweedReportedReadyType, impliedStates, conditions)
+	impliedStates = inferStateFromCondition(ctx, SeaweedWritableType, impliedStates, conditions)
 
 	hasImpliedState := func(target string) bool {
 		return len(lo.FilterValues(
@@ -141,11 +150,29 @@ func inferStateFromCondition(ctx context.Context, conditionType string, impliedS
 			impliedStates[conditionType] = inferState_SeaweedConnectionInfoType(ctx, cond)
 		case SeaweedReportedReadyType:
 			impliedStates[conditionType] = inferState_SeaweedReportedReadyType(ctx, cond)
+		case SeaweedWritableType:
+			impliedStates[conditionType] = inferState_SeaweedWritableType(ctx, cond)
 		default:
 			impliedStates[conditionType] = common.UnknownState
 		}
 	}
 	return impliedStates
+}
+
+func inferState_SeaweedWritableType(ctx context.Context, condition metav1.Condition) string {
+	log := logx.GetSlog(ctx)
+	result := common.PendingState
+	if condition.Status == metav1.ConditionTrue {
+		result = common.HealthyState
+	}
+	if condition.Status == metav1.ConditionFalse {
+		result = common.ErrorState
+	}
+	log.Debug(
+		"implied state", "state", result, "condition", condition.Type,
+		"reason", condition.Reason, "status", condition.Status,
+	)
+	return result
 }
 
 func inferState_SeaweedCustomResourceType(ctx context.Context, condition metav1.Condition) string {

--- a/internal/controller/infra/managed/objectstore/seaweedfs/status_test.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/status_test.go
@@ -1,0 +1,68 @@
+package seaweedfs
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/wandb/operator/internal/controller/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("SeaweedFS status", func() {
+	It("does not report healthy from component readiness alone", func() {
+		status, _, _ := ComputeStatus(
+			context.Background(),
+			true,
+			nil,
+			[]metav1.Condition{
+				{Type: SeaweedCustomResourceType, Status: metav1.ConditionTrue},
+				{Type: SeaweedConnectionInfoType, Status: metav1.ConditionTrue},
+				{Type: SeaweedReportedReadyType, Status: metav1.ConditionTrue},
+			},
+			nil,
+			1,
+		)
+
+		Expect(status.Ready).To(BeFalse())
+		Expect(status.State).To(Equal(common.PendingState))
+	})
+
+	It("reports an allocation failure as an error", func() {
+		status, _, _ := ComputeStatus(
+			context.Background(),
+			true,
+			nil,
+			[]metav1.Condition{
+				{Type: SeaweedCustomResourceType, Status: metav1.ConditionTrue},
+				{Type: SeaweedConnectionInfoType, Status: metav1.ConditionTrue},
+				{Type: SeaweedReportedReadyType, Status: metav1.ConditionTrue},
+				{Type: SeaweedWritableType, Status: metav1.ConditionFalse, Reason: "AllocationFailed"},
+			},
+			nil,
+			1,
+		)
+
+		Expect(status.Ready).To(BeFalse())
+		Expect(status.State).To(Equal(common.ErrorState))
+	})
+
+	It("reports healthy only after allocation succeeds", func() {
+		status, _, _ := ComputeStatus(
+			context.Background(),
+			true,
+			nil,
+			[]metav1.Condition{
+				{Type: SeaweedCustomResourceType, Status: metav1.ConditionTrue},
+				{Type: SeaweedConnectionInfoType, Status: metav1.ConditionTrue},
+				{Type: SeaweedReportedReadyType, Status: metav1.ConditionTrue},
+				{Type: SeaweedWritableType, Status: metav1.ConditionTrue, Reason: "AllocationSucceeded"},
+			},
+			nil,
+			1,
+		)
+
+		Expect(status.Ready).To(BeTrue())
+		Expect(status.State).To(Equal(common.HealthyState))
+	})
+})


### PR DESCRIPTION
## Summary
- reserve writable headroom in generated SeaweedFS volume layouts
- avoid startup DNS bind races for SeaweedFS components
- gate managed object-store readiness on a successful master allocation
- surface allocation failures through the W&B dependency status

## Validation
- `go test ./internal/controller/infra/managed/objectstore/seaweedfs`
- `./bin/golangci-lint run ./internal/controller/infra/managed/objectstore/seaweedfs/...`