### PR TITLE
fix: Stabilize v2 reconciliation writes

### DIFF
--- a/internal/controller/application_controller.go
+++ b/internal/controller/application_controller.go
@@ -30,6 +30,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,6 +84,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	logger.Info("Handling Application", "Application", app.Name)
+	statusBefore := app.DeepCopy().Status
 
 	// Add finalizer if it doesn't exist
 	if app.DeletionTimestamp == nil {
@@ -232,6 +234,9 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	if apiequality.Semantic.DeepEqual(statusBefore, app.Status) {
+		return result, nil
+	}
 	if err := r.Status().Update(ctx, &app); err != nil {
 		logger.Error("Failed to update Application status", logx.ErrAttr(err))
 		return ctrl.Result{}, err
@@ -247,6 +252,7 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, app *wa
 
 	deployment := &appsv1.Deployment{}
 	err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Name}, deployment)
+	before := deployment.DeepCopy()
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			logger.Error("Failed to get Deployment", logx.ErrAttr(err))
@@ -260,7 +266,7 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, app *wa
 	deployment.Name = app.Name
 	deployment.Namespace = app.Namespace
 
-	deployment.Spec.Template.Spec = *app.Spec.PodTemplate.Spec.DeepCopy()
+	deployment.Spec.Template.Spec = r.defaultPodSpec(app.Spec.PodTemplate.Spec)
 	deployment.Spec.Template.SetLabels(
 		utils.MergeMapsStringString(
 			deployment.Spec.Template.GetLabels(),
@@ -293,14 +299,19 @@ func (r *ApplicationReconciler) reconcileDeployment(ctx context.Context, app *wa
 		return ctrl.Result{}, err
 	}
 
-	logger.Debug("Deployment spec", "Deployment", deployment.Name, "Spec", deployment.Spec)
+	logger.Debug(
+		"Desired Deployment",
+		"Deployment", deployment.Name,
+		"containers", len(deployment.Spec.Template.Spec.Containers),
+		"initContainers", len(deployment.Spec.Template.Spec.InitContainers),
+	)
 
 	if deployment.CreationTimestamp.IsZero() {
 		if err := r.Create(ctx, deployment); err != nil {
 			logger.Error("Failed to create Deployment", logx.ErrAttr(err))
 			return ctrl.Result{}, err
 		}
-	} else {
+	} else if !deploymentManagedFieldsEqual(before, deployment) {
 		if err := r.Update(ctx, deployment); err != nil {
 			logger.Error("Failed to update Deployment", logx.ErrAttr(err))
 			return ctrl.Result{}, err
@@ -318,6 +329,34 @@ func getSelectorLabels(app *wandbv2.Application) map[string]string {
 		"app.kubernetes.io/name":     app.Name,
 		"app.kubernetes.io/instance": app.Namespace,
 	}
+}
+
+func managedObjectMetadataEqual(before, after client.Object) bool {
+	return apiequality.Semantic.DeepEqual(before.GetLabels(), after.GetLabels()) &&
+		apiequality.Semantic.DeepEqual(before.GetAnnotations(), after.GetAnnotations()) &&
+		apiequality.Semantic.DeepEqual(before.GetOwnerReferences(), after.GetOwnerReferences())
+}
+
+func (r *ApplicationReconciler) defaultPodSpec(spec corev1.PodSpec) corev1.PodSpec {
+	pod := &corev1.Pod{Spec: *spec.DeepCopy()}
+	if r.Scheme != nil {
+		r.Scheme.Default(pod)
+	}
+	return pod.Spec
+}
+
+func deploymentManagedFieldsEqual(before, after *appsv1.Deployment) bool {
+	return managedObjectMetadataEqual(before, after) &&
+		apiequality.Semantic.DeepEqual(before.Spec, after.Spec)
+}
+
+func rolloutManagedFieldsEqual(before, after *v1alpha1.Rollout) bool {
+	return managedObjectMetadataEqual(before, after) && reflect.DeepEqual(before.Spec, after.Spec)
+}
+
+func statefulSetManagedFieldsEqual(before, after *appsv1.StatefulSet) bool {
+	return managedObjectMetadataEqual(before, after) &&
+		apiequality.Semantic.DeepEqual(before.Spec, after.Spec)
 }
 
 // deleteDeployment deletes the Deployment associated with the Application
@@ -353,6 +392,7 @@ func (r *ApplicationReconciler) reconcileRollout(ctx context.Context, app *wandb
 
 	rollout := &v1alpha1.Rollout{}
 	err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Name}, rollout)
+	before := rollout.DeepCopy()
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			logger.Error("Failed to get Rollout", logx.ErrAttr(err))
@@ -366,7 +406,7 @@ func (r *ApplicationReconciler) reconcileRollout(ctx context.Context, app *wandb
 	rollout.Name = app.Name
 	rollout.Namespace = app.Namespace
 
-	rollout.Spec.Template.Spec = *app.Spec.PodTemplate.Spec.DeepCopy()
+	rollout.Spec.Template.Spec = r.defaultPodSpec(app.Spec.PodTemplate.Spec)
 	rollout.Spec.Template.SetLabels(
 		utils.MergeMapsStringString(
 			rollout.Spec.Template.GetLabels(),
@@ -399,14 +439,19 @@ func (r *ApplicationReconciler) reconcileRollout(ctx context.Context, app *wandb
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("Rollout spec", "Rollout", rollout.Name, "Spec", rollout.Spec)
+	logger.Debug(
+		"Desired Rollout",
+		"Rollout", rollout.Name,
+		"containers", len(rollout.Spec.Template.Spec.Containers),
+		"initContainers", len(rollout.Spec.Template.Spec.InitContainers),
+	)
 
 	if rollout.CreationTimestamp.IsZero() {
 		if err := r.Create(ctx, rollout); err != nil {
 			logger.Error("Failed to create Rollout", logx.ErrAttr(err))
 			return ctrl.Result{}, err
 		}
-	} else {
+	} else if !rolloutManagedFieldsEqual(before, rollout) {
 		if err := r.Update(ctx, rollout); err != nil {
 			logger.Error("Failed to update Rollout", logx.ErrAttr(err))
 			return ctrl.Result{}, err
@@ -452,6 +497,7 @@ func (r *ApplicationReconciler) reconcileStatefulSet(ctx context.Context, app *w
 
 	statefulSet := &appsv1.StatefulSet{}
 	err := r.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Name}, statefulSet)
+	before := statefulSet.DeepCopy()
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			logger.Error("Failed to get StatefulSet", logx.ErrAttr(err))
@@ -465,7 +511,7 @@ func (r *ApplicationReconciler) reconcileStatefulSet(ctx context.Context, app *w
 	statefulSet.Name = app.Name
 	statefulSet.Namespace = app.Namespace
 
-	statefulSet.Spec.Template.Spec = *app.Spec.PodTemplate.Spec.DeepCopy()
+	statefulSet.Spec.Template.Spec = r.defaultPodSpec(app.Spec.PodTemplate.Spec)
 	statefulSet.Spec.Template.SetLabels(
 		utils.MergeMapsStringString(
 			statefulSet.Spec.Template.GetLabels(),
@@ -514,14 +560,19 @@ func (r *ApplicationReconciler) reconcileStatefulSet(ctx context.Context, app *w
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("StatefulSet spec", "StatefulSet", statefulSet.Name, "Spec", statefulSet.Spec)
+	logger.Debug(
+		"Desired StatefulSet",
+		"StatefulSet", statefulSet.Name,
+		"containers", len(statefulSet.Spec.Template.Spec.Containers),
+		"initContainers", len(statefulSet.Spec.Template.Spec.InitContainers),
+	)
 
 	if statefulSet.CreationTimestamp.IsZero() {
 		if err := r.Create(ctx, statefulSet); err != nil {
 			logger.Error("Failed to create StatefulSet", logx.ErrAttr(err))
 			return ctrl.Result{}, err
 		}
-	} else {
+	} else if !statefulSetManagedFieldsEqual(before, statefulSet) {
 		if err := r.Update(ctx, statefulSet); err != nil {
 			logger.Error("Failed to update StatefulSet", logx.ErrAttr(err))
 			return ctrl.Result{}, err
@@ -720,6 +771,10 @@ func (r *ApplicationReconciler) reconcileCronJobs(ctx context.Context, app *wand
 		} else {
 			// Update existing cronjob
 			cronJobToReconcile.ResourceVersion = currentCronJob.ResourceVersion
+			if managedObjectMetadataEqual(currentCronJob, cronJobToReconcile) &&
+				apiequality.Semantic.DeepEqual(currentCronJob.Spec, cronJobToReconcile.Spec) {
+				continue
+			}
 			if err := r.Update(ctx, cronJobToReconcile); err != nil {
 				logger.Error("Failed to update CronJob", logx.ErrAttr(err), "CronJob", cronJobName)
 				return err
@@ -820,6 +875,7 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, app *wandb
 		logger.Info("Successfully created Service", "Service", desired.Name)
 		return nil
 	}
+	before := current.DeepCopy()
 
 	// Update path: preserve immutable fields
 	desired.ResourceVersion = current.ResourceVersion
@@ -845,15 +901,17 @@ func (r *ApplicationReconciler) reconcileService(ctx context.Context, app *wandb
 	current.Spec.LoadBalancerIP = desired.Spec.LoadBalancerIP
 	current.Spec.LoadBalancerSourceRanges = desired.Spec.LoadBalancerSourceRanges
 
-	logger.Info("Updating Service", "Service", current.Name)
-	if err := r.Update(ctx, current); err != nil {
-		logger.Error("Failed to update Service", logx.ErrAttr(err))
-		return err
+	if !managedObjectMetadataEqual(before, current) || !apiequality.Semantic.DeepEqual(before.Spec, current.Spec) {
+		logger.Info("Updating Service", "Service", current.Name)
+		if err := r.Update(ctx, current); err != nil {
+			logger.Error("Failed to update Service", logx.ErrAttr(err))
+			return err
+		}
+		logger.Info("Successfully updated Service", "Service", current.Name)
 	}
 
 	app.Status.ServiceStatus = &current.Status
 
-	logger.Info("Successfully updated Service", "Service", current.Name)
 	return nil
 }
 
@@ -955,6 +1013,10 @@ func (r *ApplicationReconciler) reconcileHPA(ctx context.Context, app *wandbv2.A
 
 	// Update path
 	desired.ResourceVersion = current.ResourceVersion
+	if managedObjectMetadataEqual(current, desired) && apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) {
+		app.Status.HPAStatus = &current.Status
+		return nil
+	}
 	logger.Info("Updating HPA", "HPA", desired.Name)
 	if err := r.Update(ctx, desired); err != nil {
 		logger.Error("Failed to update HPA", logx.ErrAttr(err))

--- a/internal/controller/common/resource.go
+++ b/internal/controller/common/resource.go
@@ -2,10 +2,14 @@ package common
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"maps"
 	"reflect"
 
 	"github.com/wandb/operator/internal/logx"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,10 +51,11 @@ func GetResource[T client.Object](
 type CrudAction string
 
 const (
-	NoAction     = ""
-	CreateAction = "Create"
-	UpdateAction = "Update"
-	DeleteAction = "Delete"
+	NoAction        = ""
+	CreateAction    = "Create"
+	UpdateAction    = "Update"
+	UnchangedAction = "Unchanged"
+	DeleteAction    = "Delete"
 )
 
 // CrudResource is a generic function that gets a resource, and creates it if not found, or updates it if it exists.
@@ -64,10 +69,13 @@ func CrudResource[T client.Object](ctx context.Context, c client.Client, desired
 	actualExists := !IsNil(actual) && actual.GetName() != ""
 
 	if actualExists && desiredExists {
-		action = UpdateAction
-
-		desired.SetResourceVersion(actual.GetResourceVersion())
-		err = c.Update(ctx, desired)
+		if resourceManagedFieldsEqual(desired, actual) {
+			action = UnchangedAction
+		} else {
+			action = UpdateAction
+			prepareResourceUpdate(desired, actual)
+			err = c.Update(ctx, desired)
+		}
 	}
 	if !actualExists && desiredExists {
 		action = CreateAction
@@ -77,7 +85,7 @@ func CrudResource[T client.Object](ctx context.Context, c client.Client, desired
 		action = DeleteAction
 		err = c.Delete(ctx, actual)
 	}
-	if action != NoAction {
+	if action != NoAction && action != UnchangedAction {
 		if desiredExists {
 			log.Info(string(action), "namespace", desired.GetNamespace(), "name", desired.GetName())
 		} else if actualExists {
@@ -88,6 +96,116 @@ func CrudResource[T client.Object](ctx context.Context, c client.Client, desired
 		log.Error("error on crud resource", logx.ErrAttr(err), "action", action)
 	}
 	return action, err
+}
+
+func resourceManagedFieldsEqual(desired, actual client.Object) bool {
+	if !mapContains(actual.GetLabels(), desired.GetLabels()) ||
+		!mapContains(actual.GetAnnotations(), desired.GetAnnotations()) ||
+		!ownerReferencesContain(actual.GetOwnerReferences(), desired.GetOwnerReferences()) {
+		return false
+	}
+
+	return resourceContentEqual(desired, actual)
+}
+
+func resourceContentEqual(desired, actual client.Object) bool {
+	toContent := func(obj client.Object) (map[string]any, bool) {
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return nil, false
+		}
+		content := map[string]any{}
+		if err := json.Unmarshal(data, &content); err != nil {
+			return nil, false
+		}
+		delete(content, "apiVersion")
+		delete(content, "kind")
+		delete(content, "metadata")
+		delete(content, "status")
+		normalizeSecretStringData(content)
+		return content, true
+	}
+
+	desiredContent, desiredOK := toContent(desired)
+	actualContent, actualOK := toContent(actual)
+	return desiredOK && actualOK && reflect.DeepEqual(desiredContent, actualContent)
+}
+
+func normalizeSecretStringData(content map[string]any) {
+	stringData, ok := content["stringData"].(map[string]any)
+	if !ok {
+		return
+	}
+	data, _ := content["data"].(map[string]any)
+	if data == nil {
+		data = map[string]any{}
+	}
+	for key, value := range stringData {
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		data[key] = base64.StdEncoding.EncodeToString([]byte(text))
+	}
+	content["data"] = data
+	delete(content, "stringData")
+}
+
+func mapContains(actual, desired map[string]string) bool {
+	for key, value := range desired {
+		if actual[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func ownerReferencesContain(actual, desired []metav1.OwnerReference) bool {
+	for _, desiredRef := range desired {
+		found := false
+		for _, actualRef := range actual {
+			if reflect.DeepEqual(actualRef, desiredRef) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func prepareResourceUpdate(desired, actual client.Object) {
+	desired.SetResourceVersion(actual.GetResourceVersion())
+	desired.SetUID(actual.GetUID())
+	desired.SetCreationTimestamp(actual.GetCreationTimestamp())
+	desired.SetGeneration(actual.GetGeneration())
+	desired.SetManagedFields(actual.GetManagedFields())
+	desired.SetFinalizers(actual.GetFinalizers())
+	desired.SetDeletionTimestamp(actual.GetDeletionTimestamp())
+
+	labels := maps.Clone(actual.GetLabels())
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	maps.Copy(labels, desired.GetLabels())
+	desired.SetLabels(labels)
+
+	annotations := maps.Clone(actual.GetAnnotations())
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	maps.Copy(annotations, desired.GetAnnotations())
+	desired.SetAnnotations(annotations)
+
+	ownerReferences := append([]metav1.OwnerReference(nil), actual.GetOwnerReferences()...)
+	for _, desiredRef := range desired.GetOwnerReferences() {
+		if !ownerReferencesContain(ownerReferences, []metav1.OwnerReference{desiredRef}) {
+			ownerReferences = append(ownerReferences, desiredRef)
+		}
+	}
+	desired.SetOwnerReferences(ownerReferences)
 }
 
 // IsNil checks if the generic value v is a pointer and if that pointer is nil.

--- a/internal/controller/common/resource_test.go
+++ b/internal/controller/common/resource_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type updateCountingClient struct {
+	client.Client
+	updates int
+}
+
+func (c *updateCountingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	c.updates++
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func TestCrudResourceSkipsUnchangedManagedFields(t *testing.T) {
+	t.Parallel()
+
+	actual := testConfigMap("value")
+	actual.Labels["co-manager"] = "preserve"
+	actual.Finalizers = []string{"co-manager/finalizer"}
+	c := newUpdateCountingClient(t, actual)
+	desired := testConfigMap("value")
+
+	action, err := CrudResource(context.Background(), c, desired, actual.DeepCopy())
+	if err != nil {
+		t.Fatalf("reconcile resource: %v", err)
+	}
+	if action != UnchangedAction {
+		t.Fatalf("action = %q, want %q", action, UnchangedAction)
+	}
+	if c.updates != 0 {
+		t.Fatalf("updates = %d, want 0", c.updates)
+	}
+}
+
+func TestCrudResourcePreservesCoManagedMetadataOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	actual := testConfigMap("old")
+	actual.Labels["co-manager"] = "preserve"
+	actual.Finalizers = []string{"co-manager/finalizer"}
+	c := newUpdateCountingClient(t, actual)
+	desired := testConfigMap("new")
+
+	action, err := CrudResource(context.Background(), c, desired, actual.DeepCopy())
+	if err != nil {
+		t.Fatalf("reconcile resource: %v", err)
+	}
+	if action != UpdateAction {
+		t.Fatalf("action = %q, want %q", action, UpdateAction)
+	}
+	if c.updates != 1 {
+		t.Fatalf("updates = %d, want 1", c.updates)
+	}
+
+	updated := &corev1.ConfigMap{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(actual), updated); err != nil {
+		t.Fatalf("get updated ConfigMap: %v", err)
+	}
+	if updated.Data["key"] != "new" {
+		t.Fatalf("data = %q, want new", updated.Data["key"])
+	}
+	if updated.Labels["co-manager"] != "preserve" {
+		t.Fatal("co-managed label was removed")
+	}
+	if len(updated.Finalizers) != 1 || updated.Finalizers[0] != "co-manager/finalizer" {
+		t.Fatalf("finalizers = %v, want co-manager finalizer", updated.Finalizers)
+	}
+}
+
+func TestCrudResourceTreatsSecretStringDataAsExistingData(t *testing.T) {
+	t.Parallel()
+
+	actual := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "connection", Namespace: "default"},
+		Data:       map[string][]byte{"Password": []byte("secret")},
+	}
+	c := newUpdateCountingClient(t, actual)
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "connection", Namespace: "default"},
+		StringData: map[string]string{"Password": "secret"},
+	}
+
+	action, err := CrudResource(context.Background(), c, desired, actual.DeepCopy())
+	if err != nil {
+		t.Fatalf("reconcile resource: %v", err)
+	}
+	if action != UnchangedAction {
+		t.Fatalf("action = %q, want %q", action, UnchangedAction)
+	}
+	if c.updates != 0 {
+		t.Fatalf("updates = %d, want 0", c.updates)
+	}
+}
+
+func testConfigMap(value string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "default",
+			Labels:    map[string]string{"managed-by": "wandb"},
+		},
+		Data: map[string]string{"key": value},
+	}
+}
+
+func newUpdateCountingClient(t *testing.T, objects ...client.Object) *updateCountingClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core API to scheme: %v", err)
+	}
+	return &updateCountingClient{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()}
+}

--- a/internal/controller/infra/managed/kafka/bufstream/write.go
+++ b/internal/controller/infra/managed/kafka/bufstream/write.go
@@ -138,7 +138,7 @@ func actionToCondition(conditionType string, action common.CrudAction) metav1.Co
 		return metav1.Condition{Type: conditionType, Status: metav1.ConditionFalse, Reason: common.PendingCreateReason}
 	case common.DeleteAction:
 		return metav1.Condition{Type: conditionType, Status: metav1.ConditionFalse, Reason: common.PendingDeleteReason}
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		return metav1.Condition{Type: conditionType, Status: metav1.ConditionTrue, Reason: common.ResourceExistsReason}
 	default:
 		return metav1.Condition{Type: conditionType, Status: metav1.ConditionFalse, Reason: common.NoResourceReason}

--- a/internal/controller/infra/managed/mysql/moco/write.go
+++ b/internal/controller/infra/managed/mysql/moco/write.go
@@ -155,7 +155,7 @@ func WriteState(
 			Status: metav1.ConditionFalse,
 			Reason: common.PendingDeleteReason,
 		})
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		result = append(result, metav1.Condition{
 			Type:   MySQLCustomResourceType,
 			Status: metav1.ConditionTrue,

--- a/internal/controller/infra/managed/objectstore/seaweedfs/read.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/read.go
@@ -67,7 +67,7 @@ func ReadState(
 	if actualResource != nil {
 		conditions = append(conditions, computeSeaweedReportedReadyCondition(ctx, actualResource)...)
 	}
-	log.Debug("read", "actualResource", actualResource, "rule", onDeleteRule.Policy)
+	log.Debug("read", "resourceExists", actualResource != nil, "rule", onDeleteRule.Policy)
 	return conditions
 }
 

--- a/internal/controller/infra/managed/objectstore/seaweedfs/write.go
+++ b/internal/controller/infra/managed/objectstore/seaweedfs/write.go
@@ -81,7 +81,7 @@ func WriteState(
 			Status: metav1.ConditionFalse,
 			Reason: common.PendingDeleteReason,
 		})
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		result = append(result, metav1.Condition{
 			Type:   SeaweedCustomResourceType,
 			Status: metav1.ConditionTrue,

--- a/internal/controller/infra/managed/redis/opstree/write.go
+++ b/internal/controller/infra/managed/redis/opstree/write.go
@@ -213,7 +213,7 @@ func writeStandaloneState(
 			Status: metav1.ConditionFalse,
 			Reason: common.PendingDeleteReason,
 		})
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		result = append(result, metav1.Condition{
 			Type:   RedisStandaloneCustomResourceType,
 			Status: metav1.ConditionTrue,
@@ -283,7 +283,7 @@ func writeSentinelState(
 			Status: metav1.ConditionFalse,
 			Reason: common.PendingDeleteReason,
 		})
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		result = append(result, metav1.Condition{
 			Type:   RedisSentinelCustomResourceType,
 			Status: metav1.ConditionTrue,
@@ -353,7 +353,7 @@ func writeReplicationState(
 			Status: metav1.ConditionFalse,
 			Reason: common.PendingDeleteReason,
 		})
-	case common.UpdateAction:
+	case common.UpdateAction, common.UnchangedAction:
 		result = append(result, metav1.Condition{
 			Type:   RedisReplicationCustomResourceType,
 			Status: metav1.ConditionTrue,

--- a/internal/controller/reconciler/clickhouse.go
+++ b/internal/controller/reconciler/clickhouse.go
@@ -241,6 +241,7 @@ func managedClickHouseInferStatus(
 	newConditions []metav1.Condition,
 	newInfraConn *apiv2.ClickHouseConnection,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	enabled := true
 	oldStatus := wandb.Status.ClickHouseStatus[key]
 	oldConditions := oldStatus.Conditions
@@ -258,7 +259,7 @@ func managedClickHouseInferStatus(
 		recorder.Event(wandb, e.Type, e.Reason, e.Message)
 	}
 	wandb.Status.ClickHouseStatus[key] = updatedStatus
-	err := client.Status().Update(ctx, wandb)
+	err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore)
 
 	return ctrlResult, err
 }
@@ -266,6 +267,7 @@ func managedClickHouseInferStatus(
 // external
 
 func externalClickHouseInferStatus(ctx context.Context, c client.Client, wandb *apiv2.WeightsAndBiases, key string, newConditions []metav1.Condition, newInfraConn *apiv2.ClickHouseConnection) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	oldStatus := wandb.Status.ClickHouseStatus[key]
 	oldInfraConn := oldStatus.Connection
 	state, ready, updatedConditions := external.InferExternalStatus(oldStatus.Conditions, newConditions, wandb.Generation, newInfraConn != nil)
@@ -275,7 +277,7 @@ func externalClickHouseInferStatus(ctx context.Context, c client.Client, wandb *
 		WBInfraStatus: apiv2.WBInfraStatus{Ready: ready, State: state, Conditions: updatedConditions},
 		Connection:    *conn,
 	}
-	return ctrl.Result{}, c.Status().Update(ctx, wandb)
+	return ctrl.Result{}, updateWandbStatusIfChanged(ctx, c, wandb, statusBefore)
 }
 
 // helpers

--- a/internal/controller/reconciler/kafka.go
+++ b/internal/controller/reconciler/kafka.go
@@ -127,6 +127,7 @@ func managedKafkaInferStatus(
 	newConditions []metav1.Condition,
 	newInfraConn *apiv2.KafkaConnection,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	oldConditions := wandb.Status.KafkaStatus.Conditions
 	oldInfraConn := wandb.Status.KafkaStatus.Connection
 
@@ -143,7 +144,7 @@ func managedKafkaInferStatus(
 		recorder.Event(wandb, e.Type, e.Reason, e.Message)
 	}
 	wandb.Status.KafkaStatus = updatedStatus
-	err := client.Status().Update(ctx, wandb)
+	err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore)
 
 	return ctrlResult, err
 }

--- a/internal/controller/reconciler/mysql.go
+++ b/internal/controller/reconciler/mysql.go
@@ -257,6 +257,7 @@ func managedMysqlInferStatus(
 	newConditions []metav1.Condition,
 	newInfraConn *apiv2.MysqlConnection,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	enabled := true
 	oldStatus := wandb.Status.MySQLStatus[key]
 	oldConditions := oldStatus.Conditions
@@ -275,7 +276,7 @@ func managedMysqlInferStatus(
 		recorder.Event(wandb, e.Type, e.Reason, e.Message)
 	}
 	wandb.Status.MySQLStatus[key] = updatedStatus
-	err := client.Status().Update(ctx, wandb)
+	err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore)
 
 	return ctrlResult, err
 }
@@ -283,6 +284,7 @@ func managedMysqlInferStatus(
 // external
 
 func externalMysqlInferStatus(ctx context.Context, c client.Client, wandb *apiv2.WeightsAndBiases, key string, newConditions []metav1.Condition, newInfraConn *apiv2.MysqlConnection) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	oldStatus := wandb.Status.MySQLStatus[key]
 	oldInfraConn := oldStatus.Connection
 	state, ready, updatedConditions := external.InferExternalStatus(oldStatus.Conditions, newConditions, wandb.Generation, newInfraConn != nil)
@@ -292,7 +294,7 @@ func externalMysqlInferStatus(ctx context.Context, c client.Client, wandb *apiv2
 		WBInfraStatus: apiv2.WBInfraStatus{Ready: ready, State: state, Conditions: updatedConditions},
 		Connection:    *conn,
 	}
-	return ctrl.Result{}, c.Status().Update(ctx, wandb)
+	return ctrl.Result{}, updateWandbStatusIfChanged(ctx, c, wandb, statusBefore)
 }
 
 // helpers
@@ -348,6 +350,7 @@ func runMysqlInitJobInstance(ctx context.Context, client client.Client, wandb *a
 	if wandb.Status.Wandb.MySQLInit[key].Succeeded {
 		return ctrl.Result{}, nil
 	}
+	statusBefore := wandb.DeepCopy().Status
 
 	logger := ctrl.LoggerFrom(ctx).WithName("mysqlInit").WithValues("instance", key)
 
@@ -426,7 +429,7 @@ func runMysqlInitJobInstance(ctx context.Context, client client.Client, wandb *a
 		}
 
 		wandb.Status.Wandb.MySQLInit[key] = apiv2.MigrationJobStatus{Name: jobName, Succeeded: false}
-		if err := client.Status().Update(ctx, wandb); err != nil {
+		if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -436,7 +439,7 @@ func runMysqlInitJobInstance(ctx context.Context, client client.Client, wandb *a
 	if job.Status.Succeeded > 0 {
 		logger.Info("MySQL init job succeeded")
 		wandb.Status.Wandb.MySQLInit[key] = apiv2.MigrationJobStatus{Name: jobName, Succeeded: true}
-		if err := client.Status().Update(ctx, wandb); err != nil {
+		if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -445,7 +448,7 @@ func runMysqlInitJobInstance(ctx context.Context, client client.Client, wandb *a
 	if job.Status.Failed > 0 {
 		logger.Info("MySQL init job failed")
 		wandb.Status.Wandb.MySQLInit[key] = apiv2.MigrationJobStatus{Name: jobName, Failed: true}
-		if err := client.Status().Update(ctx, wandb); err != nil {
+		if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 			return ctrl.Result{}, err
 		}
 		// We might want to return an error or just requeue

--- a/internal/controller/reconciler/objectstore.go
+++ b/internal/controller/reconciler/objectstore.go
@@ -236,6 +236,7 @@ func managedObjectStoreInferStatus(
 	newConditions []metav1.Condition,
 	newInfraConn *apiv2.ObjectStoreConnection,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	enabled := true
 	oldStatus := wandb.Status.ObjectStoreStatus[key]
 	oldConditions := oldStatus.Conditions
@@ -253,7 +254,7 @@ func managedObjectStoreInferStatus(
 		recorder.Event(wandb, e.Type, e.Reason, e.Message)
 	}
 	wandb.Status.ObjectStoreStatus[key] = updatedStatus
-	err := client.Status().Update(ctx, wandb)
+	err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore)
 
 	return ctrlResult, err
 }
@@ -261,6 +262,7 @@ func managedObjectStoreInferStatus(
 // external
 
 func externalObjectStoreInferStatus(ctx context.Context, c client.Client, wandb *apiv2.WeightsAndBiases, key string, newConditions []metav1.Condition, newInfraConn *apiv2.ObjectStoreConnection) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	oldStatus := wandb.Status.ObjectStoreStatus[key]
 	oldInfraConn := oldStatus.Connection
 	state, ready, updatedConditions := external.InferExternalStatus(oldStatus.Conditions, newConditions, wandb.Generation, newInfraConn != nil)
@@ -270,7 +272,7 @@ func externalObjectStoreInferStatus(ctx context.Context, c client.Client, wandb 
 		WBInfraStatus: apiv2.WBInfraStatus{Ready: ready, State: state, Conditions: updatedConditions},
 		Connection:    *conn,
 	}
-	return ctrl.Result{}, c.Status().Update(ctx, wandb)
+	return ctrl.Result{}, updateWandbStatusIfChanged(ctx, c, wandb, statusBefore)
 }
 
 // helpers

--- a/internal/controller/reconciler/reconcile_v2.go
+++ b/internal/controller/reconciler/reconcile_v2.go
@@ -35,6 +35,7 @@ import (
 	serverManifest "github.com/wandb/operator/pkg/wandb/manifest"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -524,6 +525,7 @@ func reconcileApplications(
 	manifest serverManifest.Manifest,
 	telemetryConfig TelemetryRuntimeConfig,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	logger := logx.GetSlog(ctx)
 	logger.Info("Reconciling applications")
 	serviceAccountName := wandb.Spec.Wandb.ServiceAccount.ServiceAccountName
@@ -593,6 +595,7 @@ func reconcileApplications(
 
 		application := &apiv2.Application{}
 		err = client.Get(ctx, types.NamespacedName{Name: app.Name, Namespace: wandb.Namespace}, application)
+		before := application.DeepCopy()
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
 				application.SetName(app.Name)
@@ -648,7 +651,7 @@ func reconcileApplications(
 			if err = client.Create(ctx, application); err != nil {
 				return ctrl.Result{}, err
 			}
-		} else {
+		} else if !applicationManagedFieldsEqual(before, application) {
 			if err = client.Update(ctx, application); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -729,11 +732,18 @@ func reconcileApplications(
 	// haven't reached the workloads yet.
 	wandb.Status.ObservedGeneration = wandb.GetGeneration()
 
-	if err := client.Status().Update(ctx, wandb); err != nil {
+	if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func applicationManagedFieldsEqual(before, after *apiv2.Application) bool {
+	return apiequality.Semantic.DeepEqual(before.Spec, after.Spec) &&
+		apiequality.Semantic.DeepEqual(before.Labels, after.Labels) &&
+		apiequality.Semantic.DeepEqual(before.Annotations, after.Annotations) &&
+		apiequality.Semantic.DeepEqual(before.OwnerReferences, after.OwnerReferences)
 }
 
 func buildHTTPRouteTemplate(wandb *apiv2.WeightsAndBiases, app serverManifest.Application) *apiv2.HTTPRouteTemplateSpec {
@@ -1107,6 +1117,7 @@ func resolveInlineFiles(ctx context.Context, client ctrlClient.Client, wandb *ap
 }
 
 func runMigrations(ctx context.Context, client ctrlClient.Client, wandb *apiv2.WeightsAndBiases, manifest serverManifest.Manifest) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	version := wandb.Spec.Wandb.Version
 
 	if wandb.Status.Wandb.Migration.Ready && wandb.Status.Wandb.Migration.Version == version {
@@ -1135,16 +1146,17 @@ func runMigrations(ctx context.Context, client ctrlClient.Client, wandb *apiv2.W
 		wandb.Status.Wandb.Migration.Ready = false
 		wandb.Status.Wandb.Migration.Reason = "Running"
 		wandb.Status.Wandb.Migration.Jobs = make(map[string]apiv2.MigrationJobStatus)
-		if err := client.Status().Update(ctx, wandb); err != nil {
+		if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 			return ctrl.Result{}, err
 		}
+		statusBefore = wandb.DeepCopy().Status
 	}
 
 	if len(manifest.Migrations) == 0 {
 		wandb.Status.Wandb.Migration.Ready = true
 		wandb.Status.Wandb.Migration.Reason = "Complete"
 		wandb.Status.Wandb.Migration.LastSuccessVersion = version
-		if err := client.Status().Update(ctx, wandb); err != nil {
+		if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -1238,7 +1250,7 @@ func runMigrations(ctx context.Context, client ctrlClient.Client, wandb *apiv2.W
 			wandb.Status.Wandb.Migration.Jobs[name] = jobStatus
 			wandb.Status.Wandb.Migration.Reason = "Running"
 			wandb.Status.Wandb.Migration.Ready = false
-			if err := client.Status().Update(ctx, wandb); err != nil {
+			if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 				return ctrl.Result{}, err
 			}
 
@@ -1282,7 +1294,7 @@ func runMigrations(ctx context.Context, client ctrlClient.Client, wandb *apiv2.W
 		wandb.Status.Wandb.Migration.Ready = false
 	}
 
-	if err := client.Status().Update(ctx, wandb); err != nil {
+	if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -1294,6 +1306,7 @@ func runMigrations(ctx context.Context, client ctrlClient.Client, wandb *apiv2.W
 }
 
 func generateSecrets(ctx context.Context, client ctrlClient.Client, wandb *apiv2.WeightsAndBiases, manifest serverManifest.Manifest) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	// Ensure any manifest-declared generated secrets exist and capture their selectors in status
 	if wandb.Status.GeneratedSecrets == nil {
 		wandb.Status.GeneratedSecrets = map[string]corev1.SecretKeySelector{}
@@ -1369,7 +1382,7 @@ func generateSecrets(ctx context.Context, client ctrlClient.Client, wandb *apiv2
 		}
 	}
 	// Persist status after updating generated secret selectors
-	if err := client.Status().Update(ctx, wandb); err != nil {
+	if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
@@ -1484,6 +1497,7 @@ func inferState(
 	ctx context.Context, client ctrlClient.Client, wandb *apiv2.WeightsAndBiases,
 ) error {
 	log := ctrl.LoggerFrom(ctx)
+	statusBefore := wandb.DeepCopy().Status
 
 	redisOk := managedInstancesReady(wandb.Spec.Redis, wandb.Status.RedisStatus, func(s apiv2.RedisSpec) bool { return s.ManagedRedis != nil }, func(s apiv2.RedisInfraStatus) bool { return s.Ready })
 	objectStoreOk := managedInstancesReady(wandb.Spec.ObjectStore, wandb.Status.ObjectStoreStatus, func(s apiv2.ObjectStoreSpec) bool { return s.ManagedObjectStore != nil }, func(s apiv2.ObjectStoreInfraStatus) bool { return s.Ready })
@@ -1497,12 +1511,10 @@ func inferState(
 		wandb.Status.Ready = false
 	}
 
-	log.Info("About to update status", "apiVersion", wandb.APIVersion, "kind", wandb.Kind)
-	if err := client.Status().Update(ctx, wandb); err != nil {
+	if err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore); err != nil {
 		log.Error(err, "Failed to update status")
 		return err
 	}
-	log.Info("Status update successful")
 	return nil
 }
 

--- a/internal/controller/reconciler/redis.go
+++ b/internal/controller/reconciler/redis.go
@@ -215,6 +215,7 @@ func managedRedisInferStatus(
 	newConditions []metav1.Condition,
 	newInfraConn *apiv2.RedisConnection,
 ) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	enabled := true
 	oldStatus := wandb.Status.RedisStatus[key]
 	oldConditions := oldStatus.Conditions
@@ -232,7 +233,7 @@ func managedRedisInferStatus(
 		recorder.Event(wandb, e.Type, e.Reason, e.Message)
 	}
 	wandb.Status.RedisStatus[key] = updatedStatus
-	err := client.Status().Update(ctx, wandb)
+	err := updateWandbStatusIfChanged(ctx, client, wandb, statusBefore)
 
 	return ctrlResult, err
 }
@@ -240,6 +241,7 @@ func managedRedisInferStatus(
 // external
 
 func externalRedisInferStatus(ctx context.Context, c client.Client, wandb *apiv2.WeightsAndBiases, key string, newConditions []metav1.Condition, newInfraConn *apiv2.RedisConnection) (ctrl.Result, error) {
+	statusBefore := wandb.DeepCopy().Status
 	oldStatus := wandb.Status.RedisStatus[key]
 	oldInfraConn := oldStatus.Connection
 	state, ready, updatedConditions := external.InferExternalStatus(oldStatus.Conditions, newConditions, wandb.Generation, newInfraConn != nil)
@@ -249,7 +251,7 @@ func externalRedisInferStatus(ctx context.Context, c client.Client, wandb *apiv2
 		WBInfraStatus: apiv2.WBInfraStatus{Ready: ready, State: state, Conditions: updatedConditions},
 		Connection:    *conn,
 	}
-	return ctrl.Result{}, c.Status().Update(ctx, wandb)
+	return ctrl.Result{}, updateWandbStatusIfChanged(ctx, c, wandb, statusBefore)
 }
 
 // helpers

--- a/internal/controller/reconciler/status_update.go
+++ b/internal/controller/reconciler/status_update.go
@@ -1,0 +1,21 @@
+package reconciler
+
+import (
+	"context"
+
+	apiv2 "github.com/wandb/operator/api/v2"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func updateWandbStatusIfChanged(
+	ctx context.Context,
+	c client.Client,
+	wandb *apiv2.WeightsAndBiases,
+	statusBefore apiv2.WeightsAndBiasesStatus,
+) error {
+	if apiequality.Semantic.DeepEqual(statusBefore, wandb.Status) {
+		return nil
+	}
+	return c.Status().Update(ctx, wandb)
+}

--- a/internal/controller/reconciler/status_update_test.go
+++ b/internal/controller/reconciler/status_update_test.go
@@ -1,0 +1,71 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	apiv2 "github.com/wandb/operator/api/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestUpdateWandbStatusIfChangedSkipsEqualStatus(t *testing.T) {
+	t.Parallel()
+
+	wandb := &apiv2.WeightsAndBiases{Status: apiv2.WeightsAndBiasesStatus{Ready: true}}
+	if err := updateWandbStatusIfChanged(context.Background(), nil, wandb, wandb.DeepCopy().Status); err != nil {
+		t.Fatalf("unchanged status returned an error: %v", err)
+	}
+}
+
+func TestUpdateWandbStatusIfChangedPersistsChange(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := apiv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("add API to scheme: %v", err)
+	}
+	wandb := &apiv2.WeightsAndBiases{
+		ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "default"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&apiv2.WeightsAndBiases{}).
+		WithObjects(wandb).
+		Build()
+
+	statusBefore := wandb.DeepCopy().Status
+	wandb.Status.Ready = true
+	if err := updateWandbStatusIfChanged(context.Background(), c, wandb, statusBefore); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	actual := &apiv2.WeightsAndBiases{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(wandb), actual); err != nil {
+		t.Fatalf("get updated resource: %v", err)
+	}
+	if !actual.Status.Ready {
+		t.Fatal("status change was not persisted")
+	}
+}
+
+func TestApplicationManagedFieldsEqual(t *testing.T) {
+	t.Parallel()
+
+	before := &apiv2.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+		Spec:       apiv2.ApplicationSpec{Kind: "Deployment"},
+	}
+	after := before.DeepCopy()
+	after.Status.Ready = true
+	if !applicationManagedFieldsEqual(before, after) {
+		t.Fatal("status-only changes should not rewrite the Application")
+	}
+
+	after.Spec.Kind = "StatefulSet"
+	if applicationManagedFieldsEqual(before, after) {
+		t.Fatal("spec changes must update the Application")
+	}
+}


### PR DESCRIPTION
## Summary

- avoid rewriting unchanged Application resources and generated workloads
- suppress semantic no-op W&B dependency and migration status updates
- preserve co-managed labels, annotations, owner references, and finalizers during updates
- treat Secret `stringData` and persisted `data` as semantically equivalent
- normalize Kubernetes pod defaults before comparing workload specifications
- avoid logging complete rendered specs or environment variables
- replace full-object debug logging with safe resource summaries

These changes reduce API-server traffic and controller feedback loops while ensuring stable inputs do not trigger replacement application rollouts.
