### PR TITLE
fix: Refresh parent status on application updates

### DIFF
--- a/internal/controller/weightsandbiases_controller.go
+++ b/internal/controller/weightsandbiases_controller.go
@@ -135,7 +135,7 @@ func (r *WeightsAndBiasesReconciler) Delete(e event.DeleteEvent) bool {
 func (r *WeightsAndBiasesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var b = ctrl.NewControllerManagedBy(mgr).
 		For(&apiv2.WeightsAndBiases{}).
-		Owns(&apiv2.Application{}).
+		Owns(&apiv2.Application{}, builder.MatchEveryOwner).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).


### PR DESCRIPTION
Application status updates weren’t triggering the parent WeightsAndBiases reconciler because the resources use plain owner references, while Owns() watched only controller owners. As a result, status.wandb.applications froze at its initial rollout snapshot. Using MatchEveryOwner makes those updates refresh the parent status.