### PR TITLE
fix: loosen release naming to allow subversions with semver

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           set -euo pipefail
 
           tag="${GITHUB_REF_NAME}"
-          if [[ ! "${tag}" =~ ^v2\.([0-9]+)\.([0-9]+)$ ]]; then
+          if [[ ! "${tag}" =~ ^v2\.([0-9]+)\.([0-9]+)(\-.*)?$ ]]; then
             echo "Expected a stable v2 tag in the form v2.x.y; got ${tag}" >&2
             exit 1
           fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Release tags following the `v2.<major>.<minor>` format can now include optional suffixes, such as prerelease or build metadata.
  - This enables packaging and publishing for appropriately formatted prerelease and build-version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->