### PR TITLE
fix: Upgrade Grafana Operator to 5.22.2

### DIFF
--- a/deploy/operator/Chart.lock
+++ b/deploy/operator/Chart.lock
@@ -22,9 +22,9 @@ dependencies:
   version: 0.58.1
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
-  version: 5.21.4
+  version: 5.22.2
 - name: telemetry
   repository: file://../telemetry
   version: 0.1.0
-digest: sha256:c236896848dcfa23f87e476e0ea552ffb874e294e08e614a7908019e03ee68a1
-generated: "2026-07-08T16:05:34.522143-07:00"
+digest: sha256:c8fc2d9388166eaff6b9b97ca0467168a50b8745814eed70b425b422cea2709d
+generated: "2026-07-20T11:55:30.771184-04:00"

--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 2.0.0-beta.1
+version: 2.0.0-beta.2
 appVersion: "2.0.0-beta.1"
 maintainers:
   - name: wandb
@@ -40,7 +40,7 @@ dependencies:
     repository: https://victoriametrics.github.io/helm-charts/
     condition: victoria-metrics-operator.enabled
   - name: grafana-operator
-    version: 5.21.4
+    version: 5.22.2
     repository: https://grafana.github.io/helm-charts
     condition: grafana-operator.enabled
   - name: telemetry


### PR DESCRIPTION
## Summary

Upgrade the embedded Grafana Operator Helm dependency from 5.21.4 to 5.22.2, bump the W&B Operator Helm chart package to `2.0.0-beta.2`, and regenerate `deploy/operator/Chart.lock`.

## Root cause

Grafana Operator 5.21.4 ships the `GrafanaNotificationPolicy` CRD with the CEL rule `!has(self.continue)`. On Kubernetes 1.30, `continue` is parsed as a CEL keyword, so the API server rejects the CRD during a full-telemetry install. Grafana Operator 5.22.2 includes the upstream fix to address the field as `self.__continue__`.

Upstream fix: https://github.com/grafana/grafana-operator/pull/2583

## Impact

Full-telemetry installations can install the Grafana notification-policy CRD on Kubernetes 1.30 without requiring a WSM-side mutation of a packaged dependency.

The chart package version is `2.0.0-beta.2`. Its `appVersion` and operator image remain `2.0.0-beta.1` because this fix changes only the packaged Helm dependency, not the controller binary. WSM/Watchtower must select chart `2.0.0-beta.2` before existing consumers receive the fix.

## Published artifact

- Chart: `oci://us-docker.pkg.dev/wandb-production/public/wandb/charts/operator:2.0.0-beta.2`
- Digest: `sha256:e3619e2a607928594af8cea449863477aa8244d112fa5b584353f0efd668746f`
- Workflow: https://github.com/wandb/operator/actions/runs/29760776828

## Validation

- `helm dependency build --skip-refresh deploy/operator`
- `helm lint --strict deploy/operator --values deploy/operator/profiles/telemetry-full.yaml`
- Rendered the full telemetry chart with `--include-crds` and verified the rule is `!has(self.__continue__)`
- Applied the affected CRD with `kubectl apply --dry-run=server` against the affected EKS Kubernetes 1.30 API server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment chart to version 2.0.0-beta.2.
  * Updated the Grafana Operator dependency to version 5.22.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->