### PR TITLE
feat(backend): Add validator for hostname spec

### DIFF
--- a/internal/webhook/v2/weightsandbiases_multi_instance_test.go
+++ b/internal/webhook/v2/weightsandbiases_multi_instance_test.go
@@ -72,6 +72,7 @@ var _ = Describe("WeightsAndBiases multi-instance infra", func() {
 		wandb := &apiv2.WeightsAndBiases{
 			ObjectMeta: metav1.ObjectMeta{Name: "wb", Namespace: "ns"},
 			Spec: apiv2.WeightsAndBiasesSpec{
+				Wandb: apiv2.WandbAppSpec{Hostname: "https://wandb.example.com"},
 				MySQL: map[string]apiv2.MySQLSpec{
 					apiv2.DefaultInstanceName: {ManagedMysql: &apiv2.ManagedMysqlSpec{Name: "wb-mysql", Namespace: "ns"}},
 					"analytics":               {ManagedMysql: &apiv2.ManagedMysqlSpec{Name: "wb-mysql-analytics", Namespace: "ns"}},

--- a/internal/webhook/v2/weightsandbiases_webhook.go
+++ b/internal/webhook/v2/weightsandbiases_webhook.go
@@ -337,6 +337,7 @@ func validateSpec(_ context.Context, newWandb, oldWandb *appsv2.WeightsAndBiases
 	var allErrors field.ErrorList
 	var warnings admission.Warnings
 
+	allErrors = append(allErrors, validateWandbSpec(newWandb)...)
 	allErrors = append(allErrors, validateMySQLSpec(newWandb)...)
 	allErrors = append(allErrors, validateRedisSpec(newWandb)...)
 	allErrors = append(allErrors, validateObjectStoreSpec(newWandb)...)
@@ -418,6 +419,19 @@ func validateMySQLChanges(newWandb, oldWandb *appsv2.WeightsAndBiases) field.Err
 				"replicas cannot be decreased; Moco does not support in-place replica reduction (use its manual stop-clustering procedure)",
 			))
 		}
+	}
+
+	return errors
+}
+
+func validateWandbSpec(wandb *appsv2.WeightsAndBiases) field.ErrorList {
+	var errors field.ErrorList
+
+	if strings.TrimSpace(wandb.Spec.Wandb.Hostname) == "" {
+		errors = append(errors, field.Required(
+			field.NewPath("spec").Child("wandb").Child("hostname"),
+			"hostname is required",
+		))
 	}
 
 	return errors

--- a/internal/webhook/v2/weightsandbiases_webhook_test.go
+++ b/internal/webhook/v2/weightsandbiases_webhook_test.go
@@ -39,7 +39,9 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		obj = &appsv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "test-ns"}}
+		obj.Spec.Wandb.Hostname = "https://wandb.example.com"
 		oldObj = &appsv2.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "test-ns"}}
+		oldObj.Spec.Wandb.Hostname = "https://wandb.example.com"
 		validator = WeightsAndBiasesCustomValidator{}
 		defaulter = WeightsAndBiasesCustomDefaulter{}
 	})
@@ -122,6 +124,31 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 			warnings, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
+		})
+
+		It("rejects create when hostname is missing", func() {
+			obj.Spec.Wandb.Hostname = ""
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.wandb.hostname"))
+			Expect(err.Error()).To(ContainSubstring("hostname is required"))
+		})
+
+		It("rejects create when hostname is only whitespace", func() {
+			obj.Spec.Wandb.Hostname = "   "
+
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.wandb.hostname"))
+		})
+
+		It("rejects update when hostname is missing", func() {
+			obj.Spec.Wandb.Hostname = ""
+
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.wandb.hostname"))
 		})
 
 		It("rejects create when Redis storage size is invalid", func() {


### PR DESCRIPTION
- Adds hostname validator to webhook
- Requires that hostname be present
- Adds relevant tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation requiring `spec.wandb.hostname` to be provided and non-blank when creating or updating a Weights & Biases resource.
  * Improved validation feedback to identify the missing hostname field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->