### PR TITLE
fix: Emit FQDN for manifest service-source URLs

### DIFF
--- a/internal/controller/reconciler/pods.go
+++ b/internal/controller/reconciler/pods.go
@@ -368,7 +368,7 @@ func resolveEnvvars(ctx context.Context, client ctrlClient.Client, wandb *v2.Wei
 				// applications status and reading from there is probably more correct
 				// Prefer deterministic manifest-derived service resolution to avoid startup races
 				// where the Service object has not been created yet.
-				if resolved, ok := manifest.ResolveServiceURL(src); ok {
+				if resolved, ok := manifest.ResolveServiceURL(src, wandb.Namespace); ok {
 					components = append(components, resolved)
 					continue
 				}
@@ -402,7 +402,13 @@ func resolveEnvvars(ctx context.Context, client ctrlClient.Client, wandb *v2.Wei
 						}
 					}
 				}
-				components = append(components, fmt.Sprintf("%s%s:%d%s", proto, serviceList.Items[0].Name, selectedPort, src.Path))
+				// Fully-qualified host (see ResolveServiceURL) so NO_PROXY cluster
+				// suffixes cover it; the Service was just listed InNamespace(wandb.Namespace).
+				svcHost := serviceList.Items[0].Name
+				if wandb.Namespace != "" {
+					svcHost = fmt.Sprintf("%s.%s.svc.cluster.local", serviceList.Items[0].Name, wandb.Namespace)
+				}
+				components = append(components, fmt.Sprintf("%s%s:%d%s", proto, svcHost, selectedPort, src.Path))
 			case "jwt-issuer-map":
 				if wandb.Spec.Wandb.InternalServiceAuth.Enabled != nil &&
 					*wandb.Spec.Wandb.InternalServiceAuth.Enabled {

--- a/internal/controller/reconciler/telemetry_test.go
+++ b/internal/controller/reconciler/telemetry_test.go
@@ -953,7 +953,7 @@ func TestResolveEnvvarsServiceSourceFromManifest(t *testing.T) {
 	}
 
 	sweepProvider := mustFindEnvVar(t, resolved, "GORILLA_SWEEP_PROVIDER")
-	if sweepProvider.Value != "http://anaconda2:8080" {
+	if sweepProvider.Value != "http://anaconda2.default.svc.cluster.local:8080" {
 		t.Fatalf("unexpected sweep provider value: %s", sweepProvider.Value)
 	}
 }
@@ -994,7 +994,7 @@ func TestResolveEnvvarsServiceSourcePortNameFromManifest(t *testing.T) {
 	}
 
 	historyStore := mustFindEnvVar(t, resolved, "GORILLA_HISTORY_STORE")
-	if historyStore.Value != "http://parquet:9000/_goRPC_" {
+	if historyStore.Value != "http://parquet.default.svc.cluster.local:9000/_goRPC_" {
 		t.Fatalf("unexpected history store value: %s", historyStore.Value)
 	}
 }

--- a/pkg/wandb/manifest/manifest.go
+++ b/pkg/wandb/manifest/manifest.go
@@ -781,7 +781,7 @@ func (m *Manifest) FeaturesEnabled(topicFeatures []string) bool {
 	return false
 }
 
-func (m *Manifest) ResolveServiceURL(src EnvSource) (string, bool) {
+func (m *Manifest) ResolveServiceURL(src EnvSource, namespace string) (string, bool) {
 	if src.Name == "" {
 		return "", false
 	}
@@ -800,7 +800,19 @@ func (m *Manifest) ResolveServiceURL(src EnvSource) (string, bool) {
 	if src.Proto != "" {
 		protoPrefix = fmt.Sprintf("%s://", src.Proto)
 	}
-	return fmt.Sprintf("%s%s:%d%s", protoPrefix, src.Name, port, src.Path), true
+	// Emit the fully-qualified service host (<name>.<namespace>.svc.cluster.local)
+	// rather than the bare service name. A bare single-label host only resolves
+	// via the consuming pod's DNS search domain, and — critically — is not
+	// matched by NO_PROXY suffix rules (.svc/.svc.cluster.local), so when a proxy
+	// is configured these internal service-to-service calls hairpin through it.
+	// The FQDN resolves unambiguously and is covered by the standard cluster-DNS
+	// NO_PROXY suffixes. Matches the FQDN convention the managed-infra reconcilers
+	// already use for datastore hosts.
+	host := src.Name
+	if namespace != "" {
+		host = fmt.Sprintf("%s.%s.svc.cluster.local", src.Name, namespace)
+	}
+	return fmt.Sprintf("%s%s:%d%s", protoPrefix, host, port, src.Path), true
 }
 
 func (a *Application) ResolveServicePortFromManifest(requestedPort string) (int32, bool) {


### PR DESCRIPTION
Manifest env sources of type: service (e.g. GORILLA_SWEEP_PROVIDER -> anaconda2, GORILLA_HISTORY_STORE -> parquet) resolved to a BARE single-label service name (http://anaconda2:8080). Bare names only resolve via the consuming pod's DNS search domain and are NOT matched by NO_PROXY suffix rules (.svc / .svc.cluster.local), so when proxy env is configured these internal service-to-service calls hairpin through the forward proxy and fail (observed via westest local-kind-proxy: gorilla UpsertSweep 500 "invalid character '<'" from a squid HTML error).

Emit the fully-qualified <name>.<namespace>.svc.cluster.local instead — the same convention the managed-infra reconcilers already use for datastore hosts — so internal calls are covered by the standard cluster-DNS NO_PROXY suffixes without enumerating every service name. Updates both the manifest-derived resolver (ResolveServiceURL, now namespace-aware) and the live-Service fallback in resolveEnvvars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service-based environment variable resolution by using fully qualified Kubernetes service URLs.
  * Ensured generated service URLs correctly include the deployment namespace for reliable in-cluster connectivity.
  * Updated resolved telemetry service URLs to use complete cluster-local DNS names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->