### PR TITLE
fix: Map external ClickHouse during v1->v2 conversion

### DIFF
--- a/api/v1/weightsandbiases_conversion_mapping.go
+++ b/api/v1/weightsandbiases_conversion_mapping.go
@@ -33,20 +33,22 @@ import (
 // Default Secret keys used by v1's legacy ref blocks when only the Secret
 // name was specified.
 const (
-	defaultMySQLPasswordSecretKey = "MYSQL_PASSWORD"
-	defaultRedisPasswordSecretKey = "REDIS_PASSWORD"
-	defaultOIDCClientSecretKey    = "OIDC_SECRET"
-	defaultBucketAccessKeyName    = "ACCESS_KEY"
-	defaultBucketSecretKeyName    = "SECRET_KEY"
+	defaultMySQLPasswordSecretKey      = "MYSQL_PASSWORD"
+	defaultRedisPasswordSecretKey      = "REDIS_PASSWORD"
+	defaultOIDCClientSecretKey         = "OIDC_SECRET"
+	defaultBucketAccessKeyName         = "ACCESS_KEY"
+	defaultBucketSecretKeyName         = "SECRET_KEY"
+	defaultClickHousePasswordSecretKey = "CLICKHOUSE_PASSWORD"
 )
 
 // Annotations carrying v1 literals the reconciler materializes into Secrets
 // post-conversion (the webhook is stateless and can't create them itself).
 const (
-	OIDCPendingAnnotation   = "legacy.operator.wandb.com/oidc-pending"
-	MySQLPendingAnnotation  = "legacy.operator.wandb.com/mysql-pending"
-	RedisPendingAnnotation  = "legacy.operator.wandb.com/redis-pending"
-	BucketPendingAnnotation = "legacy.operator.wandb.com/bucket-pending"
+	OIDCPendingAnnotation       = "legacy.operator.wandb.com/oidc-pending"
+	MySQLPendingAnnotation      = "legacy.operator.wandb.com/mysql-pending"
+	RedisPendingAnnotation      = "legacy.operator.wandb.com/redis-pending"
+	BucketPendingAnnotation     = "legacy.operator.wandb.com/bucket-pending"
+	ClickHousePendingAnnotation = "legacy.operator.wandb.com/clickhouse-pending"
 )
 
 var validSizes = map[string]appsv2.Size{
@@ -122,6 +124,9 @@ func applyGlobalMappings(globalMap map[string]interface{}, dst *appsv2.WeightsAn
 		return err
 	}
 	if err := mapBucket(globalMap, dst); err != nil {
+		return err
+	}
+	if err := mapClickHouse(globalMap, dst); err != nil {
 		return err
 	}
 
@@ -513,6 +518,86 @@ func mapMySQL(globalMap map[string]interface{}, dst *appsv2.WeightsAndBiases) er
 
 	if len(remaining) > 0 {
 		return writeAnnotation(dst, MySQLPendingAnnotation, remaining)
+	}
+	return nil
+}
+
+// clickHouseFields maps each v1 global.clickhouse.<key> to a
+// *ClickHouseConnection setter (v1 `port` is the HTTP interface).
+var clickHouseFields = []struct {
+	v1Key  string
+	setRef func(*appsv2.ClickHouseConnection, corev1.SecretKeySelector)
+}{
+	{"host", func(c *appsv2.ClickHouseConnection, s corev1.SecretKeySelector) { c.Host = s }},
+	{"port", func(c *appsv2.ClickHouseConnection, s corev1.SecretKeySelector) { c.HTTPPort = s }},
+	{"database", func(c *appsv2.ClickHouseConnection, s corev1.SecretKeySelector) { c.Database = s }},
+	{"user", func(c *appsv2.ClickHouseConnection, s corev1.SecretKeySelector) { c.Username = s }},
+	{"password", func(c *appsv2.ClickHouseConnection, s corev1.SecretKeySelector) { c.Password = s }},
+}
+
+// mapClickHouse routes v1 global.clickhouse to externalClickhouse (like
+// mapMySQL); external is asserted only when a connection field is present.
+func mapClickHouse(globalMap map[string]interface{}, dst *appsv2.WeightsAndBiases) error {
+	chMap, found, err := unstructured.NestedMap(globalMap, "clickhouse")
+	if err != nil {
+		return fmt.Errorf("spec.values.global.clickhouse: %w", err)
+	}
+	if !found || len(chMap) == 0 {
+		return nil
+	}
+
+	conn := &appsv2.ClickHouseConnection{}
+	remaining := map[string]string{}
+	sawField := false
+
+	for _, f := range clickHouseFields {
+		raw, ok := chMap[f.v1Key]
+		if !ok {
+			continue
+		}
+		ref, literal, classifyErr := classifyValueFromOrLiteral(raw)
+		if classifyErr != nil {
+			return fmt.Errorf("spec.values.global.clickhouse.%s: %w", f.v1Key, classifyErr)
+		}
+		switch {
+		case ref != nil:
+			f.setRef(conn, *ref)
+			sawField = true
+		case literal != "":
+			remaining[f.v1Key] = literal
+			sawField = true
+		}
+	}
+
+	if ps, ok, err := unstructured.NestedMap(chMap, "passwordSecret"); err != nil {
+		return fmt.Errorf("spec.values.global.clickhouse.passwordSecret: %w", err)
+	} else if ok {
+		name, _, _ := unstructured.NestedString(ps, "name")
+		alreadyHasPassword := conn.Password.Name != ""
+		if name != "" && !alreadyHasPassword {
+			key, _, _ := unstructured.NestedString(ps, "passwordKey")
+			if key == "" {
+				key = defaultClickHousePasswordSecretKey
+			}
+			conn.Password = corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: name},
+				Key:                  key,
+			}
+			delete(remaining, "password")
+			sawField = true
+		}
+	}
+
+	if !sawField {
+		return nil
+	}
+
+	dst.Spec.ClickHouse = map[string]appsv2.ClickHouseSpec{
+		appsv2.DefaultInstanceName: {ExternalClickHouse: conn},
+	}
+
+	if len(remaining) > 0 {
+		return writeAnnotation(dst, ClickHousePendingAnnotation, remaining)
 	}
 	return nil
 }

--- a/api/v1/weightsandbiases_conversion_test.go
+++ b/api/v1/weightsandbiases_conversion_test.go
@@ -1801,3 +1801,187 @@ func TestConvertTo_StashedAnnotationsReflectCRNotActiveSpec(t *testing.T) {
 	require.Equal(t, "http://wandb.from-cr", global["host"],
 		"stashed annotation must preserve the CR's raw values for round-trip")
 }
+
+func TestConvertTo_ClickHouseValueFromRef(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"host": map[string]interface{}{
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]interface{}{
+							"name": "ch-settings",
+							"key":  "endpoint",
+						},
+					},
+				},
+				"password": map[string]interface{}{
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]interface{}{
+							"name": "ch-secret",
+							"key":  "password",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	conn := dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Nil(t, dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ManagedClickHouse,
+		"external clickhouse must not also be managed")
+	require.Equal(t, "ch-settings", conn.Host.Name)
+	require.Equal(t, "endpoint", conn.Host.Key)
+	require.Equal(t, "ch-secret", conn.Password.Name)
+	require.Equal(t, "password", conn.Password.Key)
+
+	require.NotContains(t, dst.Annotations, ClickHousePendingAnnotation,
+		"no literals provided, so no annotation should be created")
+}
+
+func TestConvertTo_ClickHouseLiterals(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"host":     "clickhouse.example.com",
+				"port":     int64(8123),
+				"database": "weave",
+				"user":     "weave",
+				"password": "shh",
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	raw, ok := dst.Annotations[ClickHousePendingAnnotation]
+	require.True(t, ok, "expected clickhouse-pending annotation")
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+	require.Equal(t, "clickhouse.example.com", decoded["host"])
+	require.Equal(t, "8123", decoded["port"])
+	require.Equal(t, "weave", decoded["database"])
+	require.Equal(t, "weave", decoded["user"])
+	require.Equal(t, "shh", decoded["password"])
+
+	require.NotNil(t, dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse,
+		"externalClickhouse is always allocated; reconciler fills selectors from the annotation")
+	require.Empty(t, dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse.Host.Name)
+}
+
+func TestConvertTo_ClickHouseMixedLiteralsAndRefs(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"host": "clickhouse.example.com",
+				"port": int64(8123),
+				"password": map[string]interface{}{
+					"valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]interface{}{
+							"name": "ch-secret",
+							"key":  "password",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	conn := dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Equal(t, "ch-secret", conn.Password.Name)
+	require.Equal(t, "password", conn.Password.Key)
+
+	raw := dst.Annotations[ClickHousePendingAnnotation]
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+	require.Equal(t, "clickhouse.example.com", decoded["host"])
+	require.Equal(t, "8123", decoded["port"])
+	require.NotContains(t, decoded, "password", "password came from a ref, not a literal")
+}
+
+func TestConvertTo_ClickHouseLegacyPasswordSecret(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"host":     "clickhouse.example.com",
+				"password": "shh",
+				"passwordSecret": map[string]interface{}{
+					"name":        "ch-creds",
+					"passwordKey": "CLICKHOUSE_PASSWORD",
+				},
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	conn := dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Equal(t, "ch-creds", conn.Password.Name)
+	require.Equal(t, "CLICKHOUSE_PASSWORD", conn.Password.Key)
+
+	raw := dst.Annotations[ClickHousePendingAnnotation]
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+	require.Equal(t, "clickhouse.example.com", decoded["host"])
+	require.NotContains(t, decoded, "password", "literal password must not be stashed when passwordSecret took over")
+}
+
+func TestConvertTo_ClickHousePasswordSecretDefaultKey(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"passwordSecret": map[string]interface{}{
+					"name": "ch-creds",
+				},
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	conn := dst.Spec.ClickHouse[appsv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Equal(t, "ch-creds", conn.Password.Name)
+	require.Equal(t, "CLICKHOUSE_PASSWORD", conn.Password.Key)
+}
+
+// TestConvertTo_NoClickHouseLeavesEmpty: no clickhouse block means conversion
+// leaves it empty for the defaulter to manage.
+func TestConvertTo_NoClickHouseLeavesEmpty(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"host": "http://wandb.example.com",
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	require.Empty(t, dst.Spec.ClickHouse,
+		"no global.clickhouse means conversion leaves ClickHouse empty for the defaulter to manage")
+	require.NotContains(t, dst.Annotations, ClickHousePendingAnnotation)
+}
+
+// TestConvertTo_ClickHouseOnlyNonConnectionKeys: keys like replicated/install
+// must not be misread as an external connection.
+func TestConvertTo_ClickHouseOnlyNonConnectionKeys(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{
+			"clickhouse": map[string]interface{}{
+				"replicated": true,
+			},
+		},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+
+	require.Empty(t, dst.Spec.ClickHouse,
+		"only non-connection keys must not assert an external clickhouse")
+	require.NotContains(t, dst.Annotations, ClickHousePendingAnnotation)
+}

--- a/internal/controller/reconciler/migrate_legacy.go
+++ b/internal/controller/reconciler/migrate_legacy.go
@@ -59,7 +59,11 @@ func migrateLegacyAnnotations(
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if !mysqlChanged && !redisChanged && !bucketChanged && !oidcChanged {
+	clickHouseChanged, err := migrateLegacyClickHouse(ctx, c, wandb)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !mysqlChanged && !redisChanged && !bucketChanged && !oidcChanged && !clickHouseChanged {
 		return ctrl.Result{}, nil
 	}
 
@@ -187,6 +191,65 @@ func migrateLegacyRedis(
 
 	setExternalInstance(&wandb.Spec.Redis, func(s *apiv2.RedisSpec) { s.ExternalRedis = conn })
 	delete(wandb.Annotations, apiv1.RedisPendingAnnotation)
+	return true, nil
+}
+
+// legacyClickHousePayload is the literal-string subset the webhook couldn't
+// turn into typed selectors. Port is `any` to accept JSON number or string.
+type legacyClickHousePayload struct {
+	Host     string `json:"host,omitempty"`
+	Port     any    `json:"port,omitempty"`
+	Database string `json:"database,omitempty"`
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// migrateLegacyClickHouse drains the clickhouse-pending annotation into a
+// Secret + externalClickhouse selectors (v1 `port` fills HTTPPort).
+func migrateLegacyClickHouse(
+	ctx context.Context,
+	c ctrlClient.Client,
+	wandb *apiv2.WeightsAndBiases,
+) (bool, error) {
+	raw, ok := wandb.Annotations[apiv1.ClickHousePendingAnnotation]
+	if !ok {
+		return false, nil
+	}
+
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	var payload legacyClickHousePayload
+	if err := dec.Decode(&payload); err != nil {
+		return false, fmt.Errorf("decode %s: %w", apiv1.ClickHousePendingAnnotation, err)
+	}
+
+	secretName := fmt.Sprintf("%s-clickhouse-converted", wandb.Name)
+	conn := wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ExternalClickHouse
+	if conn == nil {
+		conn = &apiv2.ClickHouseConnection{}
+	}
+
+	data := map[string][]byte{}
+	fill := func(target *corev1.SecretKeySelector, dataKey, value string) {
+		if target.Name != "" || value == "" {
+			return
+		}
+		data[dataKey] = []byte(value)
+		*target = secretSelector(secretName, dataKey)
+	}
+
+	fill(&conn.Host, "host", payload.Host)
+	fill(&conn.HTTPPort, "httpPort", normalizePort(payload.Port))
+	fill(&conn.Database, "database", payload.Database)
+	fill(&conn.Username, "username", payload.User)
+	fill(&conn.Password, "password", payload.Password)
+
+	if err := materializeConvertedSecret(ctx, c, wandb, secretName, data); err != nil {
+		return false, err
+	}
+
+	setExternalInstance(&wandb.Spec.ClickHouse, func(s *apiv2.ClickHouseSpec) { s.ExternalClickHouse = conn })
+	delete(wandb.Annotations, apiv1.ClickHousePendingAnnotation)
 	return true, nil
 }
 

--- a/internal/controller/reconciler/migrate_legacy_test.go
+++ b/internal/controller/reconciler/migrate_legacy_test.go
@@ -88,6 +88,13 @@ func getOIDCConvertedSecret(t *testing.T, c ctrlClient.Client) (*corev1.Secret, 
 	return &secret, err
 }
 
+func getClickHouseConvertedSecret(t *testing.T, c ctrlClient.Client) (*corev1.Secret, error) {
+	t.Helper()
+	var secret corev1.Secret
+	err := c.Get(context.Background(), types.NamespacedName{Name: "wandb-clickhouse-converted", Namespace: "default"}, &secret)
+	return &secret, err
+}
+
 func TestMigrateLegacyAnnotations_NoAnnotation(t *testing.T) {
 	client, wandb := newMigrationFixture(t, nil, nil)
 	res, err := migrateLegacyAnnotations(context.Background(), client, wandb)
@@ -716,4 +723,121 @@ func TestMigrateLegacyOIDC_MalformedJSON(t *testing.T) {
 	_, err := migrateLegacyAnnotations(context.Background(), client, wandb)
 	require.Error(t, err)
 	require.Contains(t, wandb.Annotations, apiv1.OIDCPendingAnnotation)
+}
+
+func TestMigrateLegacyClickHouse_FullLiteralPayload(t *testing.T) {
+	payload := `{"host":"clickhouse.example.com","port":8123,"database":"weave","user":"weave","password":"shh"}`
+	client, wandb := newMigrationFixture(t, map[string]string{
+		apiv1.ClickHousePendingAnnotation: payload,
+	}, nil)
+
+	res, err := migrateLegacyAnnotations(context.Background(), client, wandb)
+	require.NoError(t, err)
+	require.NotZero(t, res.RequeueAfter)
+
+	secret, err := getClickHouseConvertedSecret(t, client)
+	require.NoError(t, err)
+	require.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+	require.Equal(t, []byte("clickhouse.example.com"), secret.Data["host"])
+	require.Equal(t, []byte("8123"), secret.Data["httpPort"])
+	require.Equal(t, []byte("weave"), secret.Data["database"])
+	require.Equal(t, []byte("weave"), secret.Data["username"])
+	require.Equal(t, []byte("shh"), secret.Data["password"])
+
+	var fresh apiv2.WeightsAndBiases
+	require.NoError(t, client.Get(context.Background(), types.NamespacedName{Name: "wandb", Namespace: "default"}, &fresh))
+	require.NotContains(t, fresh.Annotations, apiv1.ClickHousePendingAnnotation)
+	conn := fresh.Spec.ClickHouse[apiv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Nil(t, fresh.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse)
+	require.Equal(t, "wandb-clickhouse-converted", conn.Host.Name)
+	require.Equal(t, "host", conn.Host.Key)
+	require.Equal(t, "httpPort", conn.HTTPPort.Key)
+	require.Equal(t, "database", conn.Database.Key)
+	require.Equal(t, "username", conn.Username.Key)
+	require.Equal(t, "password", conn.Password.Key)
+	require.Empty(t, conn.TCPPort.Name)
+	require.Empty(t, conn.URL.Name)
+}
+
+func TestMigrateLegacyClickHouse_PartialPayload(t *testing.T) {
+	payload := `{"host":"clickhouse.example.com","password":"shh"}`
+	client, wandb := newMigrationFixture(t, map[string]string{
+		apiv1.ClickHousePendingAnnotation: payload,
+	}, nil)
+
+	res, err := migrateLegacyAnnotations(context.Background(), client, wandb)
+	require.NoError(t, err)
+	require.NotZero(t, res.RequeueAfter)
+
+	secret, err := getClickHouseConvertedSecret(t, client)
+	require.NoError(t, err)
+	require.Contains(t, secret.Data, "host")
+	require.Contains(t, secret.Data, "password")
+	require.NotContains(t, secret.Data, "httpPort")
+	require.NotContains(t, secret.Data, "database")
+	require.NotContains(t, secret.Data, "username")
+
+	conn := wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ExternalClickHouse
+	require.NotNil(t, conn)
+	require.Equal(t, "host", conn.Host.Key)
+	require.Equal(t, "password", conn.Password.Key)
+	require.Empty(t, conn.HTTPPort.Name)
+	require.Empty(t, conn.Database.Name)
+	require.Empty(t, conn.Username.Name)
+}
+
+// TestMigrateLegacyClickHouse_PreSetFieldsAreRespected: preset selectors are
+// not overwritten by the annotation drain.
+func TestMigrateLegacyClickHouse_PreSetFieldsAreRespected(t *testing.T) {
+	payload := `{"host":"clickhouse.example.com","password":"shh"}`
+	client, wandb := newMigrationFixture(t, map[string]string{
+		apiv1.ClickHousePendingAnnotation: payload,
+	}, func(w *apiv2.WeightsAndBiases) {
+		w.Spec.ClickHouse = map[string]apiv2.ClickHouseSpec{
+			apiv2.DefaultInstanceName: {
+				ExternalClickHouse: &apiv2.ClickHouseConnection{
+					Password: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "preset-ch"},
+						Key:                  "PRESET",
+					},
+				},
+			},
+		}
+	})
+
+	_, err := migrateLegacyAnnotations(context.Background(), client, wandb)
+	require.NoError(t, err)
+
+	secret, err := getClickHouseConvertedSecret(t, client)
+	require.NoError(t, err)
+	require.Contains(t, secret.Data, "host")
+	require.NotContains(t, secret.Data, "password", "preset password selector must be respected")
+
+	conn := wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ExternalClickHouse
+	require.Equal(t, "preset-ch", conn.Password.Name)
+	require.Equal(t, "PRESET", conn.Password.Key)
+}
+
+func TestMigrateLegacyClickHouse_PortStringified(t *testing.T) {
+	payload := `{"port":"8123"}`
+	client, wandb := newMigrationFixture(t, map[string]string{
+		apiv1.ClickHousePendingAnnotation: payload,
+	}, nil)
+
+	_, err := migrateLegacyAnnotations(context.Background(), client, wandb)
+	require.NoError(t, err)
+
+	secret, err := getClickHouseConvertedSecret(t, client)
+	require.NoError(t, err)
+	require.Equal(t, []byte("8123"), secret.Data["httpPort"])
+}
+
+func TestMigrateLegacyClickHouse_MalformedJSON(t *testing.T) {
+	client, wandb := newMigrationFixture(t, map[string]string{
+		apiv1.ClickHousePendingAnnotation: "{not json",
+	}, nil)
+	_, err := migrateLegacyAnnotations(context.Background(), client, wandb)
+	require.Error(t, err)
+	require.Contains(t, wandb.Annotations, apiv1.ClickHousePendingAnnotation)
 }


### PR DESCRIPTION
> **Stacked PR — merge bottom-up.** Part of the Operator v2 migration bugfix stack:
>
> 1. #288 — docs: chart install + v1→v2 upgrade `(base: main)`
> 1. #289 — fix: external ClickHouse conversion  ⬅ **this PR**
> 1. #290 — fix: non-UTF-8 secret regeneration

---

Part of the Operator v2 migration bugfix work from Ajay Pandey's V1 -> V2 migration test.

**Problem:** the v1 -> v2 conversion had no ClickHouse mapper. `applyGlobalMappings` mapped MySQL/Redis/bucket but ignored `global.clickhouse` (the weave-trace ClickHouse connection). The empty ClickHouse map was then defaulted to **managed**, so the operator tried to provision a ClickHouse instead of reusing the user's existing external one (`ClickHouseConnectionInfo: NoResource`).

**Fix:** mirror the MySQL/Redis conversion so an existing external ClickHouse converts to `spec.clickhouse.default.externalClickhouse`.

- `api/v1/weightsandbiases_conversion_mapping.go`: add `clickHouseFields` + `mapClickHouse`, register it in `applyGlobalMappings`, add `ClickHousePendingAnnotation`. `valueFrom` fields become selectors; literals go to the pending annotation; the legacy `passwordSecret` block is handled. v1's single `port` (HTTP, 8123) maps to `HTTPPort`.
- `internal/controller/reconciler/migrate_legacy.go`: add `migrateLegacyClickHouse` to drain the annotation into a `<name>-clickhouse-converted` secret + `externalClickhouse` selectors.
- External is only asserted when a real connection field is present, so a bare `global.clickhouse: {replicated: true}` still defaults to managed (regression-tested).
- Unit tests cover the conversion and the legacy annotation migration.

Verification: `make manifests generate sync-crd-embed` (no drift), `golangci-lint` (0 issues), targeted `go test` pass.
