### PR TITLE
fix: Reject incomplete external Redis connections

### DIFF
--- a/internal/controller/infra/external/common.go
+++ b/internal/controller/infra/external/common.go
@@ -135,11 +135,19 @@ func InferExternalStatus(
 	generation int64,
 	hasConnection bool,
 ) (string, bool, []metav1.Condition) {
-	state := common.HealthyState
-	ready := true
-	if !hasConnection {
-		state = common.ErrorState
-		ready = false
+	hasCurrentReconciledCondition := false
+	for _, condition := range newConditions {
+		if condition.Type == common.ReconciledType {
+			hasCurrentReconciledCondition = true
+			break
+		}
+	}
+	if hasConnection && !hasCurrentReconciledCondition {
+		newConditions = append(newConditions, metav1.Condition{
+			Type:   common.ReconciledType,
+			Status: metav1.ConditionTrue,
+			Reason: common.ResourceExistsReason,
+		})
 	}
 
 	updatedConditions := common.ComputeConditionUpdates(
@@ -148,6 +156,19 @@ func InferExternalStatus(
 		generation,
 		common.DefaultConditionExpiry,
 	)
+
+	ready := hasConnection
+	for _, condition := range newConditions {
+		if condition.Type == common.ReconciledType && condition.Status != metav1.ConditionTrue {
+			ready = false
+			break
+		}
+	}
+
+	state := common.HealthyState
+	if !ready {
+		state = common.ErrorState
+	}
 	return state, ready, updatedConditions
 }
 

--- a/internal/controller/infra/external/common_test.go
+++ b/internal/controller/infra/external/common_test.go
@@ -1,0 +1,52 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wandb/operator/internal/controller/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInferExternalStatusUsesCurrentReconcileCondition(t *testing.T) {
+	failed := metav1.Condition{
+		Type:    common.ReconciledType,
+		Status:  metav1.ConditionFalse,
+		Reason:  common.ResourceErrorReason,
+		Message: "invalid connection",
+	}
+
+	state, ready, conditions := InferExternalStatus(nil, []metav1.Condition{failed}, 2, true)
+
+	require.Equal(t, common.ErrorState, state)
+	require.False(t, ready)
+	require.Len(t, conditions, 1)
+	require.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+	require.Equal(t, int64(2), conditions[0].ObservedGeneration)
+}
+
+func TestInferExternalStatusClearsRecoveredFailure(t *testing.T) {
+	old := metav1.Condition{
+		Type:               common.ReconciledType,
+		Status:             metav1.ConditionFalse,
+		Reason:             common.ResourceErrorReason,
+		Message:            "invalid connection",
+		ObservedGeneration: 1,
+	}
+
+	state, ready, conditions := InferExternalStatus([]metav1.Condition{old}, nil, 2, true)
+
+	require.Equal(t, common.HealthyState, state)
+	require.True(t, ready)
+	require.Len(t, conditions, 1)
+	require.Equal(t, metav1.ConditionTrue, conditions[0].Status)
+	require.Equal(t, common.ResourceExistsReason, conditions[0].Reason)
+	require.Equal(t, int64(2), conditions[0].ObservedGeneration)
+}
+
+func TestInferExternalStatusRequiresConnection(t *testing.T) {
+	state, ready, _ := InferExternalStatus(nil, nil, 1, false)
+
+	require.Equal(t, common.ErrorState, state)
+	require.False(t, ready)
+}

--- a/internal/controller/infra/external/redis/redis.go
+++ b/internal/controller/infra/external/redis/redis.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
+	"strings"
 
 	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/internal/controller/common"
 	"github.com/wandb/operator/internal/controller/infra/external"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,9 +49,20 @@ func WriteState(
 	if err != nil {
 		logger.Error(err, "failed to resolve external redis fields")
 		return []metav1.Condition{{
-			Type:   "Reconciled",
-			Status: metav1.ConditionFalse,
-			Reason: "ApiError",
+			Type:    common.ReconciledType,
+			Status:  metav1.ConditionFalse,
+			Reason:  common.ApiErrorReason,
+			Message: err.Error(),
+		}}
+	}
+
+	if err := validateConnectionData(data); err != nil {
+		logger.Error(err, "invalid external redis connection")
+		return []metav1.Condition{{
+			Type:    common.ReconciledType,
+			Status:  metav1.ConditionFalse,
+			Reason:  common.ResourceErrorReason,
+			Message: err.Error(),
 		}}
 	}
 
@@ -79,6 +93,23 @@ func WriteState(
 
 	nsName := types.NamespacedName{Namespace: wandb.Namespace, Name: connectionSecretName(key)}
 	return external.WriteConnectionSecret(ctx, c, wandb, nsName, data)
+}
+
+func validateConnectionData(data map[string]string) error {
+	host := strings.TrimSpace(data["Host"])
+	if host == "" {
+		return fmt.Errorf("external Redis host is empty")
+	}
+
+	portValue := strings.TrimSpace(data["Port"])
+	port, err := strconv.Atoi(portValue)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("external Redis port %q must be an integer between 1 and 65535", portValue)
+	}
+
+	data["Host"] = host
+	data["Port"] = strconv.Itoa(port)
+	return nil
 }
 
 func ReadState(

--- a/internal/controller/infra/external/redis/redis_test.go
+++ b/internal/controller/infra/external/redis/redis_test.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/internal/controller/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -23,19 +26,15 @@ func redisSel(key string) corev1.SecretKeySelector {
 	}
 }
 
-func TestWriteStateAddsCACertPathAndTLSWhenCACertPresent(t *testing.T) {
+func redisWriteStateFixture(t *testing.T, sourceData map[string][]byte) (ctrlclient.Client, *apiv2.WeightsAndBiases) {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, apiv2.AddToScheme(scheme))
 
 	source := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: redisSourceSecretName, Namespace: "default"},
-		Data: map[string][]byte{
-			"Host":     []byte("redis.example.com"),
-			"Port":     []byte("6379"),
-			"Password": []byte("secret"),
-			"SslCa":    []byte("---ca---"),
-		},
+		Data:       sourceData,
 	}
 	wandb := &apiv2.WeightsAndBiases{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "apps.wandb.com/v2", Kind: "WeightsAndBiases"},
@@ -43,15 +42,32 @@ func TestWriteStateAddsCACertPathAndTLSWhenCACertPresent(t *testing.T) {
 		Spec: apiv2.WeightsAndBiasesSpec{
 			Redis: map[string]apiv2.RedisSpec{apiv2.DefaultInstanceName: {
 				ExternalRedis: &apiv2.RedisConnection{
-					Host:     redisSel("Host"),
-					Port:     redisSel("Port"),
-					Password: redisSel("Password"),
-					SslCa:    redisSel("SslCa"),
+					Host: redisSel("Host"),
+					Port: redisSel("Port"),
 				},
 			}},
 		},
 	}
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wandb, source).Build()
+	if _, ok := sourceData["Password"]; ok {
+		connection := wandb.Spec.Redis[apiv2.DefaultInstanceName]
+		connection.ExternalRedis.Password = redisSel("Password")
+		wandb.Spec.Redis[apiv2.DefaultInstanceName] = connection
+	}
+	if _, ok := sourceData["SslCa"]; ok {
+		connection := wandb.Spec.Redis[apiv2.DefaultInstanceName]
+		connection.ExternalRedis.SslCa = redisSel("SslCa")
+		wandb.Spec.Redis[apiv2.DefaultInstanceName] = connection
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(wandb, source).Build(), wandb
+}
+
+func TestWriteStateAddsCACertPathAndTLSWhenCACertPresent(t *testing.T) {
+	client, wandb := redisWriteStateFixture(t, map[string][]byte{
+		"Host":     []byte("redis.example.com"),
+		"Port":     []byte("6379"),
+		"Password": []byte("secret"),
+		"SslCa":    []byte("---ca---"),
+	})
 
 	conditions := WriteState(context.Background(), client, wandb, apiv2.DefaultInstanceName, wandb.Spec.Redis[apiv2.DefaultInstanceName].ExternalRedis)
 	require.Nil(t, conditions)
@@ -65,6 +81,36 @@ func TestWriteStateAddsCACertPathAndTLSWhenCACertPresent(t *testing.T) {
 	require.Equal(t, "redis.example.com:6379", parsed.Host)
 	require.Equal(t, "true", parsed.Query().Get("tls"))
 	require.Equal(t, caCertPath, parsed.Query().Get("caCertPath"))
+}
+
+func TestWriteStateRejectsInvalidRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string][]byte
+	}{
+		{name: "empty host", data: map[string][]byte{"Host": {}, "Port": []byte("6379")}},
+		{name: "empty port", data: map[string][]byte{"Host": []byte("redis.example.com"), "Port": {}}},
+		{name: "non-numeric port", data: map[string][]byte{"Host": []byte("redis.example.com"), "Port": []byte("redis")}},
+		{name: "zero port", data: map[string][]byte{"Host": []byte("redis.example.com"), "Port": []byte("0")}},
+		{name: "port above range", data: map[string][]byte{"Host": []byte("redis.example.com"), "Port": []byte("65536")}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, wandb := redisWriteStateFixture(t, test.data)
+
+			conditions := WriteState(context.Background(), client, wandb, apiv2.DefaultInstanceName, wandb.Spec.Redis[apiv2.DefaultInstanceName].ExternalRedis)
+
+			require.Len(t, conditions, 1)
+			require.Equal(t, common.ReconciledType, conditions[0].Type)
+			require.Equal(t, metav1.ConditionFalse, conditions[0].Status)
+			require.Equal(t, common.ResourceErrorReason, conditions[0].Reason)
+			require.NotEmpty(t, conditions[0].Message)
+
+			err := client.Get(context.Background(), types.NamespacedName{Name: ConnectionSecretName, Namespace: "default"}, &corev1.Secret{})
+			require.True(t, apierrors.IsNotFound(err))
+		})
+	}
 }
 
 func redisConnectionData(secret *corev1.Secret) map[string]string {

--- a/internal/webhook/v2/weightsandbiases_webhook.go
+++ b/internal/webhook/v2/weightsandbiases_webhook.go
@@ -471,6 +471,7 @@ func validateMySQLSpec(wandb *appsv2.WeightsAndBiases) field.ErrorList {
 func validateRedisSpec(wandb *appsv2.WeightsAndBiases) field.ErrorList {
 	var errors field.ErrorList
 	redisPath := field.NewPath("spec").Child("redis")
+	_, hasPendingLegacyRedis := wandb.Annotations[v1.RedisPendingAnnotation]
 
 	errors = append(errors, validateHasDefaultInstance(wandb.Spec.Redis, redisPath)...)
 
@@ -484,22 +485,38 @@ func validateRedisSpec(wandb *appsv2.WeightsAndBiases) field.ErrorList {
 			))
 		}
 
-		managed := spec.ManagedRedis
-		if managed == nil {
+		if externalRedis := spec.ExternalRedis; externalRedis != nil && !hasPendingLegacyRedis {
+			externalPath := instancePath.Child("externalRedis")
+			errors = append(errors, validateRequiredSecretSelector(externalRedis.Host, externalPath.Child("host"))...)
+			errors = append(errors, validateRequiredSecretSelector(externalRedis.Port, externalPath.Child("port"))...)
+		}
+
+		if spec.ManagedRedis == nil {
 			continue
 		}
 
-		if managed.StorageSize != "" {
-			if _, err := resource.ParseQuantity(managed.StorageSize); err != nil {
+		if spec.ManagedRedis.StorageSize != "" {
+			if _, err := resource.ParseQuantity(spec.ManagedRedis.StorageSize); err != nil {
 				errors = append(errors, field.Invalid(
 					instancePath.Child("managedRedis").Child("storageSize"),
-					managed.StorageSize,
+					spec.ManagedRedis.StorageSize,
 					"must be a valid resource quantity (e.g., '10Gi')",
 				))
 			}
 		}
 	}
 
+	return errors
+}
+
+func validateRequiredSecretSelector(selector corev1.SecretKeySelector, path *field.Path) field.ErrorList {
+	var errors field.ErrorList
+	if selector.Name == "" {
+		errors = append(errors, field.Required(path.Child("name"), "secret name is required"))
+	}
+	if selector.Key == "" {
+		errors = append(errors, field.Required(path.Child("key"), "secret key is required"))
+	}
 	return errors
 }
 

--- a/internal/webhook/v2/weightsandbiases_webhook_test.go
+++ b/internal/webhook/v2/weightsandbiases_webhook_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "github.com/wandb/operator/api/v1"
 	appsv2 "github.com/wandb/operator/api/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,6 +123,49 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 	Context("When creating or updating WeightsAndBiases under Validating Webhook", func() {
 		It("allows create when ManagedRedis is nil", func() {
 			warnings, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())		})
+
+		It("rejects external Redis without host and port selectors", func() {
+			obj.Spec.Redis = map[string]appsv2.RedisSpec{
+				appsv2.DefaultInstanceName: {ExternalRedis: &appsv2.RedisConnection{}},
+			}
+
+			_, err := validator.ValidateCreate(ctx, obj)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("externalRedis.host.name"))
+			Expect(err.Error()).To(ContainSubstring("externalRedis.host.key"))
+			Expect(err.Error()).To(ContainSubstring("externalRedis.port.name"))
+			Expect(err.Error()).To(ContainSubstring("externalRedis.port.key"))
+		})
+
+		It("allows external Redis with host and port selectors", func() {
+			obj.Spec.Redis = map[string]appsv2.RedisSpec{
+				appsv2.DefaultInstanceName: {
+					ExternalRedis: &appsv2.RedisConnection{
+						Host: secretKeySelector("redis", "host"),
+						Port: secretKeySelector("redis", "port"),
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, obj)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("allows external Redis while v1 literal values are pending materialization", func() {
+			obj.Annotations = map[string]string{
+				appsv1.RedisPendingAnnotation: `{"host":"redis.example.com","port":"6379"}`,
+			}
+			obj.Spec.Redis = map[string]appsv2.RedisSpec{
+				appsv2.DefaultInstanceName: {ExternalRedis: &appsv2.RedisConnection{}},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, obj)
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
 		})
@@ -293,7 +337,8 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 
 			warnings, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(warnings).To(BeEmpty())		})
+			Expect(warnings).To(BeEmpty())
+		})
 
 		It("rejects even Keeper replica counts", func() {
 			obj.Spec.ClickHouse = map[string]appsv2.ClickHouseSpec{appsv2.DefaultInstanceName: {ManagedClickHouse: &appsv2.ManagedClickHouseSpec{
@@ -364,4 +409,11 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+func secretKeySelector(name, key string) corev1.SecretKeySelector {
+	return corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: name},
+		Key:                  key,
+	}
 }


### PR DESCRIPTION
## Summary
- validate required external Redis secret selectors and resolved host/port values
- prevent malformed generated Redis URLs
- make external infrastructure readiness honor current reconcile failures and recovery

## Testing
- `go test ./internal/controller/infra/external/... ./internal/webhook/v2`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for external Redis host and port configuration, including required secret references and valid port ranges.
  * Redis connection values are normalized before connection credentials are stored.
  * Legacy Redis pending configurations remain supported.

* **Bug Fixes**
  * External resource readiness and health now reflect current reconciliation conditions.
  * Recovered resources correctly return to a healthy, ready state.
  * Invalid Redis configurations no longer create connection secrets and report standardized errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->