### PR TITLE
fix: Update-images

### DIFF
--- a/hack/testing-manifests/server-manifest/0.83.0-clickhouse-keeper.1/manifest.yaml
+++ b/hack/testing-manifests/server-manifest/0.83.0-clickhouse-keeper.1/manifest.yaml
@@ -26,7 +26,12 @@ clickhouse:
         tag: "25.8.16.10002.altinitystable"
 
 clickhouseKeeper:
-  default: {}
+  default:
+    images:
+      keeper:
+        registry: "docker.io"
+        repository: "altinity/clickhouse-keeper"
+        tag: "25.8.16.10002.altinitystable"
 
 generatedSecrets:
   - name: session-key

--- a/hack/testing-manifests/server-manifest/0.83.0-clickhouse-keeper.2/manifest.yaml
+++ b/hack/testing-manifests/server-manifest/0.83.0-clickhouse-keeper.2/manifest.yaml
@@ -26,7 +26,12 @@ clickhouse:
         tag: "25.8.16.10002.altinitystable"
 
 clickhouseKeeper:
-  default: {}
+  default:
+    images:
+      keeper:
+        registry: "docker.io"
+        repository: "altinity/clickhouse-keeper"
+        tag: "25.8.16.10002.altinitystable"
 
 generatedSecrets:
   - name: session-key

--- a/internal/controller/infra/managed/clickhouse/altinity/keeper/spec.go
+++ b/internal/controller/infra/managed/clickhouse/altinity/keeper/spec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wandb/operator/pkg/utils"
 	chkv1 "github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse-keeper.altinity.com/v1"
 	chiv1 "github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse.altinity.com/v1"
+	"github.com/wandb/operator/pkg/wandb/manifest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,14 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+func KeeperImage(img manifest.ImageRef, globalImageRegistry string) string {
+	if out := img.GetImage(globalImageRegistry); out != "" {
+		return out
+	}
+	// Fallback for older manifests that don't supply the image.
+	return defaultKeeperImage
+}
 
 // ToKeeperVendorSpec builds the ClickHouseKeeperInstallation CR that coordinates
 // ReplicatedMergeTree replication. nsName comes from altinity.KeeperNsName —
@@ -28,6 +37,7 @@ func ToKeeperVendorSpec(
 	spec *apiv2.ManagedClickHouseSpec,
 	scheme *runtime.Scheme,
 	nsName types.NamespacedName,
+	mfst manifest.Manifest,
 ) (*chkv1.ClickHouseKeeperInstallation, error) {
 	_, log := logx.WithSlog(ctx, logx.ClickHouse)
 	if spec == nil {
@@ -50,7 +60,7 @@ func ToKeeperVendorSpec(
 		Containers: []corev1.Container{
 			{
 				Name:            keeperContainerName,
-				Image:           KeeperImage,
+				Image:           KeeperImage(mfst.ClickhouseKeeper["default"].Images["keeper"], wandb.Spec.Global.ImageRegistry),
 				SecurityContext: keeperContainerSecurityContext(),
 			},
 		},

--- a/internal/controller/infra/managed/clickhouse/altinity/keeper/spec_test.go
+++ b/internal/controller/infra/managed/clickhouse/altinity/keeper/spec_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wandb/operator/pkg/utils"
 	chkv1 "github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse-keeper.altinity.com/v1"
 	chiv1 "github.com/wandb/operator/pkg/vendored/altinity-clickhouse/clickhouse.altinity.com/v1"
+	"github.com/wandb/operator/pkg/wandb/manifest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,7 @@ var _ = Describe("Keeper vendor spec", func() {
 			},
 		}
 
-		chk, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName())
+		chk, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName(), manifest.Manifest{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(chk).NotTo(BeNil())
 		Expect(chk.Name).To(Equal("clickhouse-chk"))
@@ -48,7 +49,7 @@ var _ = Describe("Keeper vendor spec", func() {
 
 		Expect(chk.Spec.Templates.PodTemplates).To(HaveLen(1))
 		container := chk.Spec.Templates.PodTemplates[0].Spec.Containers[0]
-		Expect(container.Image).To(Equal(KeeperImage))
+		Expect(container.Image).To(Equal(KeeperImage(manifest.ImageRef{}, "")))
 		Expect(container.Name).To(Equal(keeperContainerName))
 		Expect(container.Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("250m")))
 
@@ -60,17 +61,36 @@ var _ = Describe("Keeper vendor spec", func() {
 		Expect(*sc.RunAsNonRoot).To(BeTrue())
 	})
 
+	It("uses the Keeper image from the server manifest", func() {
+		wandb := keeperWandb()
+		wandb.Spec.Global.ImageRegistry = "myregistry.io"
+		mfst := manifest.Manifest{
+			ClickhouseKeeper: map[string]manifest.InfraConfig{
+				"default": {
+					Images: map[string]manifest.ImageRef{
+						"keeper": {Registry: "docker.io", Repository: "altinity/clickhouse-keeper", Tag: "25.8"},
+					},
+				},
+			},
+		}
+
+		chk, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName(), mfst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chk.Spec.Templates.PodTemplates[0].Spec.Containers[0].Image).
+			To(Equal("myregistry.io/docker.io/altinity/clickhouse-keeper:25.8"))
+	})
+
 	It("errors when keeper storage size is unset (no operator defaults)", func() {
 		wandb := keeperWandb()
 		wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse.Keeper = apiv2.ClickHouseKeeperSpec{}
-		_, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName())
+		_, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName(), manifest.Manifest{})
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("omits fixed IDs in OpenShift mode", func() {
 		utils.SetOpenShiftMode(true)
 		wandb := keeperWandb()
-		chk, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName())
+		chk, err := ToKeeperVendorSpec(context.Background(), wandb, wandb.Spec.ClickHouse[apiv2.DefaultInstanceName].ManagedClickHouse, keeperScheme(), keeperNsName(), manifest.Manifest{})
 		Expect(err).NotTo(HaveOccurred())
 		sc := chk.Spec.Templates.PodTemplates[0].Spec.SecurityContext
 		Expect(sc.RunAsUser).To(BeNil())

--- a/internal/controller/infra/managed/clickhouse/altinity/keeper/values.go
+++ b/internal/controller/infra/managed/clickhouse/altinity/keeper/values.go
@@ -4,8 +4,10 @@ const (
 	// KeeperModuleName is the W&B component label value for Keeper resources.
 	KeeperModuleName = "clickhouse-keeper"
 
-	// KeeperImage pins the Keeper image to the managed ClickHouse server version.
-	KeeperImage = "altinity/clickhouse-keeper:25.8.16.10002.altinitystable"
+	// TODO: remove this hardcoded default once all supported manifest versions
+	// supply clickhouseKeeper.<instance>.images.keeper. Pinned to the managed
+	// ClickHouse server version.
+	defaultKeeperImage = "altinity/clickhouse-keeper:25.8.16.10002.altinitystable"
 
 	// KeeperClientPort is the ZooKeeper-compatible client port.
 	KeeperClientPort = 2181

--- a/internal/controller/reconciler/clickhouse.go
+++ b/internal/controller/reconciler/clickhouse.go
@@ -198,7 +198,7 @@ func managedClickHouseWriteState(
 	}
 
 	// Translate the Keeper and ClickHouse CRs; WriteState writes Keeper first.
-	desiredKeeper, err := keeper.ToKeeperVendorSpec(ctx, wandb, spec, client.Scheme(), altinity.KeeperNsName(spec))
+	desiredKeeper, err := keeper.ToKeeperVendorSpec(ctx, wandb, spec, client.Scheme(), altinity.KeeperNsName(spec), mfst)
 	if err != nil {
 		log.Error(err, "failed to translate Keeper spec to vendor spec")
 		return []metav1.Condition{


### PR DESCRIPTION
Missed hardcoded clickhouse-keeper image when moving image refs to manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ClickHouse Keeper now honors the Keeper container image defined in the server manifest, including custom registry and tag/version.
  * If the manifest omits the image, the standard default Keeper image is used.

* **Bug Fixes**
  * Ensured manifest-based Keeper image settings are propagated correctly through deployment state handling.

* **Tests**
  * Updated and added tests to verify manifest image selection (including registry override), default fallback behavior, and OpenShift deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->