### PR TITLE
fix: Jwt-map

### DIFF
--- a/api/v1/weightsandbiases_conversion_mapping.go
+++ b/api/v1/weightsandbiases_conversion_mapping.go
@@ -201,6 +201,8 @@ func mapInternalJWTIssuer(values map[string]interface{}, dst *appsv2.WeightsAndB
 	}
 	if issuer != "" {
 		dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer = issuer
+	} else {
+		dst.Spec.Wandb.InternalServiceAuth.Enabled = ptr.To(false)
 	}
 	return nil
 }

--- a/api/v1/weightsandbiases_conversion_test.go
+++ b/api/v1/weightsandbiases_conversion_test.go
@@ -355,6 +355,9 @@ func TestConvertTo_InternalJWTIssuerFromGlobal(t *testing.T) {
 	})
 	require.NoError(t, src.ConvertTo(dst))
 	require.Equal(t, "https://gke-issuer.example.com", dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer)
+	// An issuer means v1 was using internal service auth; leave Enabled unset so
+	// the defaulter turns it on.
+	require.Nil(t, dst.Spec.Wandb.InternalServiceAuth.Enabled)
 }
 
 func TestConvertTo_InternalJWTIssuerFallsBackToApp(t *testing.T) {
@@ -419,6 +422,8 @@ func TestConvertTo_InternalJWTIssuerEmptyGlobalFallsBackToApp(t *testing.T) {
 	})
 	require.NoError(t, src.ConvertTo(dst))
 	require.Equal(t, "from-app", dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer)
+	// A value anywhere outranks an empty list, so this is not a "disabled" signal.
+	require.Nil(t, dst.Spec.Wandb.InternalServiceAuth.Enabled)
 }
 
 func TestConvertTo_InternalJWTIssuerAbsent(t *testing.T) {
@@ -428,6 +433,34 @@ func TestConvertTo_InternalJWTIssuerAbsent(t *testing.T) {
 	})
 	require.NoError(t, src.ConvertTo(dst))
 	require.Empty(t, dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer)
+	require.NotNil(t, dst.Spec.Wandb.InternalServiceAuth.Enabled)
+	require.False(t, *dst.Spec.Wandb.InternalServiceAuth.Enabled)
+}
+
+// The shape that regressed in the field: an explicitly empty per-app map and no
+// global one. v1 asserted no issuers, so v2 must say off rather than leave
+// internalServiceAuth empty for the defaulter to turn on with a guessed issuer.
+func TestConvertTo_InternalJWTIssuerEmptyAppDisables(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"app": map[string]interface{}{"internalJWTMap": []interface{}{}},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+	require.Empty(t, dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer)
+	require.NotNil(t, dst.Spec.Wandb.InternalServiceAuth.Enabled)
+	require.False(t, *dst.Spec.Wandb.InternalServiceAuth.Enabled)
+}
+
+func TestConvertTo_InternalJWTIssuerEmptyBothDisables(t *testing.T) {
+	dst := &appsv2.WeightsAndBiases{}
+	src := newV1(map[string]interface{}{
+		"global": map[string]interface{}{"internalJWTMap": []interface{}{}},
+		"app":    map[string]interface{}{"internalJWTMap": []interface{}{}},
+	})
+	require.NoError(t, src.ConvertTo(dst))
+	require.Empty(t, dst.Spec.Wandb.InternalServiceAuth.OIDCIssuer)
+	require.NotNil(t, dst.Spec.Wandb.InternalServiceAuth.Enabled)
+	require.False(t, *dst.Spec.Wandb.InternalServiceAuth.Enabled)
 }
 
 func TestConvertTo_IngressEnabledByChartDefaults(t *testing.T) {

--- a/internal/webhook/v2/weightsandbiases_webhook.go
+++ b/internal/webhook/v2/weightsandbiases_webhook.go
@@ -110,7 +110,7 @@ func (d *WeightsAndBiasesCustomDefaulter) Default(ctx context.Context, obj runti
 		wandb.Spec.Wandb.InternalServiceAuth.Enabled = ptr.To(true)
 	}
 
-	if wandb.Spec.Wandb.InternalServiceAuth.OIDCIssuer == "" {
+	if wandb.Spec.Wandb.InternalServiceAuth.OIDCIssuer == "" && wandb.Spec.Wandb.InternalServiceAuth.Enabled != nil && *wandb.Spec.Wandb.InternalServiceAuth.Enabled{
 		wandb.Spec.Wandb.InternalServiceAuth.OIDCIssuer = "https://kubernetes.default.svc.cluster.local"
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal service authentication handling when no JWT issuer is configured.
  * Authentication is now explicitly disabled when issuer configuration is empty.
  * Prevented default OIDC issuers from being applied when authentication is disabled.
  * Preserved existing behavior when valid app or global issuer configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->