### PR TITLE
fix: Prevent conflicting Console ownership

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,8 +18,6 @@ jobs:
           go-version: 1.25
       - name: Install dependencies
         run: go mod download
-      - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
       - name: Tests
         run: make test-coverage
 

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GINKGO = $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
@@ -229,6 +230,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.63.4
+GINKGO_VERSION ?= $(shell go list -m -f "{{ .Version }}" github.com/onsi/ginkgo/v2)
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -277,7 +279,7 @@ endef
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 $(GINKGO): $(LOCALBIN)
-	test -s $(LOCALBIN)/ginkgo || GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@latest
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
 
 include dep-management.mk olm.mk ginko.mk

--- a/ginko.mk
+++ b/ginko.mk
@@ -2,7 +2,7 @@
 test-ginko: manifests generate fmt vet envtest ginkgo ## Run tests.
 	@echo "Running tests..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	ginkgo -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
+	$(GINKGO) -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
 		--skip-package e2e \
 		--output-interceptor-mode=none \
 		--no-color=false \
@@ -15,7 +15,7 @@ test-ginko: manifests generate fmt vet envtest ginkgo ## Run tests.
 test-verbose: manifests generate fmt vet envtest ginkgo ## Run tests with verbose output.
 	@echo "Running tests in verbose mode..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	ginkgo -p -r -v --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
+	$(GINKGO) -p -r -v --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
 		--skip-package e2e \
 		--output-interceptor-mode=none \
 		--no-color=false \
@@ -28,7 +28,7 @@ test-verbose: manifests generate fmt vet envtest ginkgo ## Run tests with verbos
 test-watch: manifests generate fmt vet envtest ginkgo ## Run tests in watch mode.
 	@echo "Running tests in watch mode..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	ginkgo watch -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
+	$(GINKGO) watch -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
 		--skip-package e2e \
 		--output-interceptor-mode=none \
 		--no-color=false \
@@ -40,7 +40,7 @@ test-watch: manifests generate fmt vet envtest ginkgo ## Run tests in watch mode
 test-coverage: manifests generate fmt vet envtest ginkgo ## Run tests with coverage report.
 	@echo "Running tests with coverage..."
 	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	ginkgo -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
+	$(GINKGO) -p -r --compilers=4 --timeout=5m --fail-fast --race --trace --randomize-all \
 		--skip-package e2e \
 		--output-interceptor-mode=none \
 		--no-color=false \

--- a/internal/controller/console_ownership.go
+++ b/internal/controller/console_ownership.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+
+	wandbcomv1 "github.com/wandb/operator/api/v1"
+	"github.com/wandb/operator/pkg/wandb/spec"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	helmReleaseNameAnnotation = "meta.helm.sh/release-name"
+	standaloneConsoleRelease  = "console"
+)
+
+var errStandaloneConsoleOwnsService = stderrors.New("standalone Console release owns the bundled Console service")
+
+// validateConsoleServiceOwnership prevents the main W&B release from enabling
+// its bundled Console when the standalone Console Helm release already owns the
+// Service that the bundled chart would render.
+func validateConsoleServiceOwnership(
+	ctx context.Context,
+	k8sClient client.Client,
+	wandb *wandbcomv1.WeightsAndBiases,
+	desiredSpec *spec.Spec,
+) error {
+	if desiredSpec == nil || !desiredSpec.Values.GetBool("console.install") {
+		return nil
+	}
+
+	serviceKey := types.NamespacedName{
+		Name:      wandb.Name + "-console",
+		Namespace: wandb.Namespace,
+	}
+	service := &corev1.Service{}
+	if err := k8sClient.Get(ctx, serviceKey, service); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("check Console Service ownership: %w", err)
+	}
+
+	if service.Annotations[helmReleaseNameAnnotation] != standaloneConsoleRelease {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: release %q owns Service %q in namespace %q",
+		errStandaloneConsoleOwnsService,
+		standaloneConsoleRelease,
+		service.Name,
+		service.Namespace,
+	)
+}
+
+func isConsoleServiceOwnershipConflict(err error) bool {
+	return stderrors.Is(err, errStandaloneConsoleOwnsService)
+}

--- a/internal/controller/console_ownership.go
+++ b/internal/controller/console_ownership.go
@@ -61,7 +61,8 @@ func validateConsoleServiceOwnership(
 		return fmt.Errorf("check Console Service ownership: %w", err)
 	}
 
-	if service.Annotations[helmReleaseNameAnnotation] != standaloneConsoleRelease {
+	ownerRelease := service.Annotations[helmReleaseNameAnnotation]
+	if ownerRelease != standaloneConsoleRelease || ownerRelease == wandb.Name {
 		return nil
 	}
 

--- a/internal/controller/console_ownership.go
+++ b/internal/controller/console_ownership.go
@@ -45,7 +45,10 @@ func validateConsoleServiceOwnership(
 	wandb *wandbcomv1.WeightsAndBiases,
 	desiredSpec *spec.Spec,
 ) error {
-	if desiredSpec == nil || !desiredSpec.Values.GetBool("console.install") {
+	// The operator-wandb chart defaults bundled Console on. Treat an omitted
+	// value as enabled so a partial/transient spec cannot bypass the ownership
+	// check before Helm coalesces the chart defaults during Apply.
+	if desiredSpec == nil || !desiredSpec.Values.GetBool("console.install", true) {
 		return nil
 	}
 

--- a/internal/controller/console_ownership_test.go
+++ b/internal/controller/console_ownership_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	wandbcomv1 "github.com/wandb/operator/api/v1"
+	"github.com/wandb/operator/pkg/wandb/spec"
+	"github.com/wandb/operator/pkg/wandb/spec/channel/deployer"
+	"github.com/wandb/operator/pkg/wandb/spec/channel/deployer/deployerfakes"
+	"github.com/wandb/operator/pkg/wandb/spec/charts"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type recordingChart struct {
+	applied bool
+}
+
+func (c *recordingChart) Apply(
+	context.Context,
+	client.Client,
+	*wandbcomv1.WeightsAndBiases,
+	*runtime.Scheme,
+	spec.Values,
+) error {
+	c.applied = true
+	return nil
+}
+
+func (c *recordingChart) Prune(
+	context.Context,
+	client.Client,
+	*wandbcomv1.WeightsAndBiases,
+	*runtime.Scheme,
+	spec.Values,
+) error {
+	return nil
+}
+
+func (c *recordingChart) Chart() (*chart.Chart, error) {
+	return &chart.Chart{}, nil
+}
+
+func TestValidateConsoleServiceOwnership(t *testing.T) {
+	t.Parallel()
+
+	ownedByStandaloneConsole := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb-console",
+			Namespace: "customer",
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name": "console",
+			},
+		},
+	}
+	ownedByAnotherRelease := ownedByStandaloneConsole.DeepCopy()
+	ownedByAnotherRelease.Annotations["meta.helm.sh/release-name"] = "another-release"
+
+	tests := []struct {
+		name            string
+		consoleEnabled  bool
+		objects         []runtime.Object
+		wantConflictErr bool
+	}{
+		{
+			name:           "allows standalone service while bundled console is disabled",
+			consoleEnabled: false,
+			objects:        []runtime.Object{ownedByStandaloneConsole},
+		},
+		{
+			name:           "allows bundled console when target service does not exist",
+			consoleEnabled: true,
+		},
+		{
+			name:           "allows bundled console when another Helm release owns the target service",
+			consoleEnabled: true,
+			objects:        []runtime.Object{ownedByAnotherRelease},
+		},
+		{
+			name:            "rejects bundled console when standalone release owns the target service",
+			consoleEnabled:  true,
+			objects:         []runtime.Object{ownedByStandaloneConsole},
+			wantConflictErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add core scheme: %v", err)
+			}
+			objects := make([]runtime.Object, len(tt.objects))
+			for i, object := range tt.objects {
+				objects[i] = object.DeepCopyObject()
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+			wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "customer"}}
+			desired := &spec.Spec{Values: spec.Values{
+				"console": map[string]interface{}{"install": tt.consoleEnabled},
+			}}
+
+			err := validateConsoleServiceOwnership(context.Background(), client, wandb, desired)
+			if tt.wantConflictErr {
+				if !errors.Is(err, errStandaloneConsoleOwnsService) {
+					t.Fatalf("expected ownership conflict, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReconcileStopsBeforeApplyOnConsoleOwnershipConflict(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := wandbcomv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add W&B scheme: %v", err)
+	}
+
+	wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "customer"}}
+	standaloneService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wandb-console",
+		Namespace: "customer",
+		Annotations: map[string]string{
+			helmReleaseNameAnnotation: standaloneConsoleRelease,
+		},
+	}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(wandb, standaloneService).Build()
+
+	recorder := record.NewFakeRecorder(10)
+	chart := &recordingChart{}
+	deployerClient := &deployerfakes.FakeDeployerInterface{}
+	deployerClient.GetSpecReturns(&spec.Spec{
+		Chart: chart,
+		Values: spec.Values{
+			"console": map[string]interface{}{"install": true},
+		},
+	}, nil)
+	reconciler := &WeightsAndBiasesReconciler{
+		Client:         k8sClient,
+		DeployerClient: deployerClient,
+		Scheme:         scheme,
+		Recorder:       recorder,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name:      wandb.Name,
+		Namespace: wandb.Namespace,
+	}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.RequeueAfter != time.Hour {
+		t.Fatalf("expected one-hour requeue, got %v", result.RequeueAfter)
+	}
+	if chart.applied {
+		t.Fatal("chart Apply was called despite the ownership conflict")
+	}
+
+	activeState := &corev1.Secret{}
+	err = k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "wandb-spec-active",
+		Namespace: wandb.Namespace,
+	}, activeState)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no active spec to be saved, got %v", err)
+	}
+
+	foundConflictEvent := false
+	for len(recorder.Events) > 0 {
+		if event := <-recorder.Events; event == "Warning ConsoleOwnershipConflict Bundled Console cannot be enabled while the standalone Console release owns its Service" {
+			foundConflictEvent = true
+		}
+	}
+	if !foundConflictEvent {
+		t.Fatal("expected a controlled ConsoleOwnershipConflict warning event")
+	}
+}
+
+func TestReconcileDetectsConsoleOwnershipConflictWhenSpecIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := wandbcomv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add W&B scheme: %v", err)
+	}
+
+	wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "customer"}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(wandb).Build()
+
+	recorder := record.NewFakeRecorder(20)
+	chart := &charts.RepoRelease{
+		URL:     "https://charts.wandb.ai",
+		Name:    "operator-wandb",
+		Version: "0.44.6",
+	}
+	deployerClient := &deployerfakes.FakeDeployerInterface{}
+	deployerClient.GetSpecCalls(func(options deployer.GetSpecOptions) (*spec.Spec, error) {
+		if options.ActiveState != nil {
+			return options.ActiveState, nil
+		}
+		return &spec.Spec{
+			Chart: chart,
+			Values: spec.Values{
+				"console": map[string]interface{}{"install": true},
+			},
+		}, nil
+	})
+	reconciler := &WeightsAndBiasesReconciler{
+		Client:         k8sClient,
+		DeployerClient: deployerClient,
+		Scheme:         scheme,
+		Recorder:       recorder,
+		DryRun:         true,
+	}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name:      wandb.Name,
+		Namespace: wandb.Namespace,
+	}}
+
+	if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+	if deployerClient.GetSpecCallCount() != 1 {
+		t.Fatalf("expected one deployer call after initial reconcile, got %d", deployerClient.GetSpecCallCount())
+	}
+	for len(recorder.Events) > 0 {
+		<-recorder.Events
+	}
+
+	standaloneService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      "wandb-console",
+		Namespace: wandb.Namespace,
+		Annotations: map[string]string{
+			helmReleaseNameAnnotation: standaloneConsoleRelease,
+		},
+	}}
+	if err := k8sClient.Create(context.Background(), standaloneService); err != nil {
+		t.Fatalf("create standalone Console Service: %v", err)
+	}
+
+	if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("unchanged reconcile: %v", err)
+	}
+	if deployerClient.GetSpecCallCount() != 2 {
+		t.Fatalf("expected two deployer calls after unchanged reconcile, got %d", deployerClient.GetSpecCallCount())
+	}
+	if deployerClient.GetSpecArgsForCall(1).ActiveState == nil {
+		t.Fatal("expected unchanged reconcile to load the active spec")
+	}
+
+	foundConflictEvent := false
+	for len(recorder.Events) > 0 {
+		if event := <-recorder.Events; event == "Warning ConsoleOwnershipConflict Bundled Console cannot be enabled while the standalone Console release owns its Service" {
+			foundConflictEvent = true
+		}
+	}
+	if !foundConflictEvent {
+		t.Fatal("expected the unchanged reconciliation to report a ConsoleOwnershipConflict warning event")
+	}
+}

--- a/internal/controller/console_ownership_test.go
+++ b/internal/controller/console_ownership_test.go
@@ -82,9 +82,12 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 	}
 	ownedByAnotherRelease := ownedByStandaloneConsole.DeepCopy()
 	ownedByAnotherRelease.Annotations["meta.helm.sh/release-name"] = "another-release"
+	ownedByMainConsoleRelease := ownedByStandaloneConsole.DeepCopy()
+	ownedByMainConsoleRelease.Name = "console-console"
 
 	tests := []struct {
 		name            string
+		wandbName       string
 		consoleEnabled  bool
 		objects         []runtime.Object
 		wantConflictErr bool
@@ -102,6 +105,12 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 			name:           "allows bundled console when another Helm release owns the target service",
 			consoleEnabled: true,
 			objects:        []runtime.Object{ownedByAnotherRelease},
+		},
+		{
+			name:           "allows bundled console when the main release is named console",
+			wandbName:      standaloneConsoleRelease,
+			consoleEnabled: true,
+			objects:        []runtime.Object{ownedByMainConsoleRelease},
 		},
 		{
 			name:            "rejects bundled console when standalone release owns the target service",
@@ -124,7 +133,11 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 				objects[i] = object.DeepCopyObject()
 			}
 			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
-			wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: "wandb", Namespace: "customer"}}
+			wandbName := tt.wandbName
+			if wandbName == "" {
+				wandbName = "wandb"
+			}
+			wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: wandbName, Namespace: "customer"}}
 			desired := &spec.Spec{Values: spec.Values{
 				"console": map[string]interface{}{"install": tt.consoleEnabled},
 			}}

--- a/internal/controller/console_ownership_test.go
+++ b/internal/controller/console_ownership_test.go
@@ -89,6 +89,7 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 		name            string
 		wandbName       string
 		consoleEnabled  bool
+		omitInstall     bool
 		objects         []runtime.Object
 		wantConflictErr bool
 	}{
@@ -118,6 +119,12 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 			objects:         []runtime.Object{ownedByStandaloneConsole},
 			wantConflictErr: true,
 		},
+		{
+			name:            "rejects omitted install when standalone release owns the target service",
+			omitInstall:     true,
+			objects:         []runtime.Object{ownedByStandaloneConsole},
+			wantConflictErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -138,9 +145,11 @@ func TestValidateConsoleServiceOwnership(t *testing.T) {
 				wandbName = "wandb"
 			}
 			wandb := &wandbcomv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{Name: wandbName, Namespace: "customer"}}
-			desired := &spec.Spec{Values: spec.Values{
-				"console": map[string]interface{}{"install": tt.consoleEnabled},
-			}}
+			desiredValues := spec.Values{}
+			if !tt.omitInstall {
+				desiredValues["console"] = map[string]interface{}{"install": tt.consoleEnabled}
+			}
+			desired := &spec.Spec{Values: desiredValues}
 
 			err := validateConsoleServiceOwnership(context.Background(), client, wandb, desired)
 			if tt.wantConflictErr {

--- a/internal/controller/weightsandbiases_controller.go
+++ b/internal/controller/weightsandbiases_controller.go
@@ -226,6 +226,23 @@ func (r *WeightsAndBiasesReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	hasNotBeenFlaggedForDeletion := wandb.ObjectMeta.DeletionTimestamp.IsZero()
 	if hasNotBeenFlaggedForDeletion {
+		if err := validateConsoleServiceOwnership(ctx, r.Client, wandb, desiredSpec); err != nil {
+			if isConsoleServiceOwnershipConflict(err) {
+				statusManager.Set(status.InvalidConfig)
+				r.Recorder.Event(
+					wandb,
+					corev1.EventTypeWarning,
+					"ConsoleOwnershipConflict",
+					"Bundled Console cannot be enabled while the standalone Console release owns its Service",
+				)
+				log.Error(err, "Refusing to enable bundled Console")
+				return ctrlqueue.Requeue(desiredSpec)
+			}
+
+			log.Error(err, "Failed to check Console Service ownership")
+			return ctrlqueue.RequeueWithError(err)
+		}
+
 		if currentActiveSpec != nil {
 			log.Info("Active spec found", "spec", currentActiveSpec.SensitiveValuesMasked())
 			if currentActiveSpec.IsEqual(desiredSpec) {


### PR DESCRIPTION
## What changed

Before applying a desired W&B spec, the v1 Operator now checks whether that spec enables bundled Console while the target Console Service is already owned by the standalone `console` Helm release. On conflict it records a controlled warning, marks the configuration invalid, requeues, and does not apply the chart or save the desired spec as active.

## Why

Console moved to a standalone deployment, but the Operator merges higher-precedence CR/user input ahead of the deployments-provided spec. A stale higher-precedence `console.install: true` can therefore override the authoritative managed-install `false` and make the main `wandb` release contend for the standalone Console Service. Removing obsolete deployment workflows does not prevent that merge-path conflict.

## Impact

Normal configurations are unchanged. The guard only blocks the conflicting ownership state, and it reads only the target Service metadata.

## Validation

- `go test -count=1 ./internal/controller/...`
- complete non-e2e package suite with Kubernetes 1.35 envtest
- `git diff --check origin/v1...HEAD`
