### PR TITLE
fix: Guard gateway deletion by ownership

### DIFF
--- a/internal/controller/reconciler/gateway.go
+++ b/internal/controller/reconciler/gateway.go
@@ -146,6 +146,7 @@ func reconcileGateway(ctx context.Context, c ctrlClient.Client, wandb *apiv2.Wei
 }
 
 func deleteGateway(ctx context.Context, c ctrlClient.Client, wandb *apiv2.WeightsAndBiases) error {
+	ctx, logger := logx.WithSlog(ctx, "Gateway")
 	gatewayName := fmt.Sprintf("%s-gateway", wandb.Name)
 	gw := &gatewayv1.Gateway{}
 	if !utils.IsRegistered(c.Scheme(), gw) {
@@ -157,6 +158,16 @@ func deleteGateway(ctx context.Context, c ctrlClient.Client, wandb *apiv2.Weight
 		}
 		return err
 	}
+	// Never delete a gateway we don't own: a user may run their own gateway that
+	// happens to share our derived name.
+	owned, err := controllerutil.HasOwnerReference(gw.GetOwnerReferences(), wandb, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return nil
+	}
+	logger.Info("Deleting gateway", "gateway", gatewayName)
 	return c.Delete(ctx, gw)
 }
 

--- a/internal/controller/reconciler/gateway_test.go
+++ b/internal/controller/reconciler/gateway_test.go
@@ -1,0 +1,84 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiv2 "github.com/wandb/operator/api/v2"
+	"github.com/wandb/operator/pkg/utils"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func gatewayTestClient(t *testing.T, objects ...ctrlClient.Object) ctrlClient.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiv2.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	// deleteGateway no-ops unless the Gateway CRD is registered in the cluster;
+	// mirror the runtime discovery that populates this set.
+	utils.AddServerResource("Gateway.gateway.networking.k8s.io/v1")
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objects) > 0 {
+		builder.WithObjects(objects...)
+	}
+	return builder.Build()
+}
+
+func newWandbForGateway() *apiv2.WeightsAndBiases {
+	return &apiv2.WeightsAndBiases{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps.wandb.com/v2", Kind: "WeightsAndBiases"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb",
+			Namespace: "default",
+			UID:       "wandb-uid",
+		},
+	}
+}
+
+func TestDeleteGatewayDeletesOwnedGateway(t *testing.T) {
+	wandb := newWandbForGateway()
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb-gateway",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps.wandb.com/v2",
+				Kind:       "WeightsAndBiases",
+				Name:       wandb.Name,
+				UID:        wandb.UID,
+			}},
+		},
+	}
+	client := gatewayTestClient(t, wandb, gw)
+
+	require.NoError(t, deleteGateway(context.Background(), client, wandb))
+
+	err := client.Get(context.Background(), types.NamespacedName{Name: "wandb-gateway", Namespace: "default"}, &gatewayv1.Gateway{})
+	require.True(t, apiErrors.IsNotFound(err), "owned gateway should have been deleted")
+}
+
+func TestDeleteGatewayDoesNotDeleteUnownedGateway(t *testing.T) {
+	wandb := newWandbForGateway()
+	// A user-provided gateway that happens to share our derived name; no owner ref to us.
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wandb-gateway",
+			Namespace: "default",
+		},
+	}
+	client := gatewayTestClient(t, wandb, gw)
+
+	require.NoError(t, deleteGateway(context.Background(), client, wandb))
+
+	err := client.Get(context.Background(), types.NamespacedName{Name: "wandb-gateway", Namespace: "default"}, &gatewayv1.Gateway{})
+	require.NoError(t, err, "unowned gateway must not be deleted")
+}


### PR DESCRIPTION
deleteGateway removed any Gateway matching the derived name "<name>-gateway", so a user-provided Gateway sharing that name would be deleted on teardown. Verify ownership via HasOwnerReference before deleting and only act on Gateways we created.