### PR TITLE
chore: Updating victoria-metrics-operator

### DIFF
--- a/deploy/operator/Chart.lock
+++ b/deploy/operator/Chart.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 0.26.3
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts/
-  version: 0.58.1
+  version: 0.66.3
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: 5.21.4
 - name: telemetry
   repository: file://../telemetry
   version: 0.1.0
-digest: sha256:b03eebae8a867a43e00fe2d3bd3e89c2af552a0c998d0046c56865128090f123
-generated: "2026-07-17T13:39:19.593182-07:00"
+digest: sha256:96d5bb09606c6a9dd3bc9a53434e32fa21c84ae76bd713041eff56693d0b69d6
+generated: "2026-08-11T13:17:40.604478-05:00"

--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     repository: https://helm.altinity.com
     condition: altinity-clickhouse-operator.enabled
   - name: victoria-metrics-operator
-    version: 0.58.1
+    version: 0.66.3
     repository: https://victoriametrics.github.io/helm-charts/
     condition: victoria-metrics-operator.enabled
   - name: grafana-operator

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -221,6 +221,10 @@ victoria-metrics-operator:
     # Install Victoria CRDs through Helm's CRD phase so telemetry resources
     # in this chart can be created in the same release.
     plain: true
+    upgrade:
+      enabled: true
+      # Required to update the Victoria CRD Fields
+      forceConflicts: true
 
 grafana-operator:
   # Helm dependency conditions are boolean-only, so full installs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the VictoriaMetrics Operator deployment to a newer release.
  * Enabled forced-conflict upgrades for VictoriaMetrics custom resource definitions during Helm deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->