### PR TITLE
feat: Add OLM bundling scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ hack/testing-manifests/wandb/.generated/*.yaml
 
 # various util artifacts
 .k8s-images
+
+# Python bytecode (hack/scripts/*.py)
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ tilt-settings.star
 hack/testing-manifests/wandb/.generated/*.yaml
 /tilt_bin
 /dist
+/bundle
+/bundle.Dockerfile
 
 .DS_Store
 

--- a/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -41,21 +41,6 @@ spec:
       name: weightsandbiases.apps.wandb.com
       version: v1
     required:
-    - description: Redis standalone instance managed by the OT Container Kit redis-operator.
-      displayName: Redis
-      kind: Redis
-      name: redis.redis.redis.opstreelabs.in
-      version: v1beta2
-    - description: Redis replication instance managed by the OT Container Kit redis-operator.
-      displayName: Redis Replication
-      kind: RedisReplication
-      name: redisreplications.redis.redis.opstreelabs.in
-      version: v1beta2
-    - description: Redis Sentinel instance managed by the OT Container Kit redis-operator.
-      displayName: Redis Sentinel
-      kind: RedisSentinel
-      name: redissentinels.redis.redis.opstreelabs.in
-      version: v1beta2
     - description: ClickHouse cluster managed by the Altinity ClickHouse operator.
       displayName: ClickHouse Installation
       kind: ClickHouseInstallation

--- a/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -4,11 +4,74 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: operator.v0.0.0
+    categories: AI/Machine Learning,Developer Tools
+    certified: "false"
+    containerImage: us-docker.pkg.dev/wandb-production/public/wandb/operator:0.0.0
+    description: Operator for Weights and Biases, enabling seamless integration and
+      management of machine learning experiments in Kubernetes environments.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: wandb-system
+    repository: https://github.com/wandb/operator
+    support: WeightsAndBiases
+  name: wandb-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Application is the Schema for the applications API.
+      displayName: Application
+      kind: Application
+      name: applications.apps.wandb.com
+      version: v2
+    - description: WeightsAndBiases is the Schema for the weightsandbiases API.
+      displayName: Weights And Biases
+      kind: WeightsAndBiases
+      name: weightsandbiases.apps.wandb.com
+      version: v2
+    - description: WeightsAndBiases is the Schema for the weightsandbiases API
+      displayName: Weights & Biases
+      kind: WeightsAndBiases
+      name: weightsandbiases.apps.wandb.com
+      version: v1
+    required:
+    - description: Redis standalone instance managed by the OT Container Kit redis-operator.
+      displayName: Redis
+      kind: Redis
+      name: redis.redis.redis.opstreelabs.in
+      version: v1beta2
+    - description: Redis replication instance managed by the OT Container Kit redis-operator.
+      displayName: Redis Replication
+      kind: RedisReplication
+      name: redisreplications.redis.redis.opstreelabs.in
+      version: v1beta2
+    - description: Redis Sentinel instance managed by the OT Container Kit redis-operator.
+      displayName: Redis Sentinel
+      kind: RedisSentinel
+      name: redissentinels.redis.redis.opstreelabs.in
+      version: v1beta2
+    - description: ClickHouse cluster managed by the Altinity ClickHouse operator.
+      displayName: ClickHouse Installation
+      kind: ClickHouseInstallation
+      name: clickhouseinstallations.clickhouse.altinity.com
+      version: v1
+    - description: Grafana instance managed by the Grafana operator.
+      displayName: Grafana
+      kind: Grafana
+      name: grafanas.grafana.integreatly.org
+      version: v1beta1
+    - description: VictoriaMetrics single-node instance managed by the VictoriaMetrics
+        operator.
+      displayName: VMSingle
+      kind: VMSingle
+      name: vmsingles.operator.victoriametrics.com
+      version: v1beta1
   description: |-
     The Weights and Biases Operator simplifies the management of machine learning experiments, tracking, and infrastructure. It integrates with Kubernetes to deploy and manage Weights and Biases instances.
     Features:
@@ -18,8 +81,8 @@ spec:
     - Integration with popular ML frameworks
   displayName: Weights & Biases Operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAbwAAABxCAMAAACZb+YzAAAAwFBMVEX///8AAAD/zDOVlZU+Pj7v7+/a2tr8/Pz/yib/yy2NjY339/f/yyr/yRb/yiF4eHjMzMzm5ub/+eu8vLz//fjg4ODCwsJlZWW0tLRtbW1gYGCmpqaIiIienp7S0tIVFRWtra1QUFD/4pv/9d7/78pHR0csLCz/3Yf/56xYWFh1dXUjIyNLS0v/12v/89j/8dA1NTX/6rj/5KP/0U7/2XT/zj7/1F8oKCgQEBD/2HH/0En/3Yb/7L3/4JP/+vAdHR3XioaIAAATAElEQVR4nO1dZ2MiLRA2GntN0Rhb1PTevXsvyd3//1evuizMwACDkvLB59NdZFmWYYZpDJmMwPHHc/b1v8dMfOw/zbLZ2dP+J3S9wRLn9VI5my03ysexe35Mei7VP2NhbDDHbSOboFy/i9vzU130nK1fxO15gwQXcobnLBK15zvVc7Yenas3mAPMcLbxFLPnWVn1XL6N2fMGCU4agHjlPxF7/guXRba+UVri46mEpjhiz/cN1HPk/XSDOaalz+IPxNPZxn28njcQuMBTHLHnYyw2NxpLfKApjqtWfNqy+HJUC3v9XKWS63dH+e8eC8Iz0AnrJ6xHdndZzT6ARG58rDPGb0Wn+W8L4mBc/e4hSQDWK3EY72RWn+OFIwXLcl2Us/7W/ZwfFbDwW5z2I9W+WnE2HZODal9tEeiNyMZ+dBljXmA47Hc7BQaXn9TFHDeeGa+/TVrX6lN/291STayKGoNXH6hp0rGj2uc47ceqfd7d8pIY0k7P1nqyQzT344AzZoDtwZ6HgsfP9Uap1OCQIzOTopDTfP8l6fmFo8Ruc74GzNmQ036s2nuI1zNH5HxDn/FJBg45Y9bwK9d29nl88TF957z8ItTj9fdxOn38y+n65xHvRv14NOi08/lCFwrRJuurMFYh3hwPeyu8ywA0Cmv/xehR4YcRr3otfzprqT/31RMrUG9F4m1t/V6ffHfYdFu7P4RfnI/4vD1vYh1ODv29eip/CJec1j3Uj+3VdlmFR+zx4lkMbOTn1tSgd0YO/WjSzHVbO0XYvtrujCuHFoY9PayMW22k1BfbnX5z8tto+qs3b6pPzaX8uaOPU/0UPp/5Qqc/OCB0s4NmiqvD3uTabIAW4irQiPdJTpPqzgCRwaczF3daXSVDz/p7I+ekLmg4EKZb02Z1j2V/XfNHub4oDZWH+Zix2NeVkuqob7Dp1cqvWwC7KyOLTYAdOOTfnCfaqj3rDZ62ReeEqeEVWC+jgT7SIN4SnQmmHqERBwD50mZrdeXEkfe7NFRU85a/daaQND21/a720yL1s1Q6V9E4U+A92PKRBSxh1+K9c6BuMn1pKwHJTY5eAKjNmVAhsoa232VnFfJnxeeMd9mAiWeV9BXUbCXrMkVWerwaL+v040ErUFgUYHtG/0JjtEm9jm9OpULBkQoWVHnEA9uvu50ff1+Tba9c/9y8BjRgf3O0PP2Ox6qn42ba1T9fA0Kd4YJLPGwTbZu/7+/yvCBzTBv1RqOe5Sbz7e/urhLgvYQD9lMD6f8Db3PBWQe23yVjHVoaSG7IWRowgInnUqiRNaRt6e8vjUWg4M+UabfdvZ8wjYS7t+yi5+x5cA4EkhXeGUJSk8GpAw/beN8s5eoaGksRjdlFPPR5SMk6ydYT33+5xHMgs3H8nPZcq88CbUKkRxOiAgNv6n5O/e2eMPVym0Yj92QbazKAieeMEd7AlkDAvtRBMLbUiJgmdAF7Loem3V6zvyyjWRZ+uSmIY9vQMiM+8dbQ3QOItwdbqjHNkNk91/+j5QlN61rPnIiTAmImw0OFoUlNr9wce2isiGcTm3I2/furHWjIpD2ZAm2PN+lf3zTaxXNYvteNnllBpxQjOF7PFGlS0+v46HmWhHq3bUuTrq117C4+8TLI4Sv+dm/McLbMCaf7sW/2nG0E7ahwuEfupoavmTat9a6t86Vs8BtLC6kMc9w5nmFwiIdCSWLT+1M2pziO4+S8ZPZcCkpCOiDGS8OQmlvXzp5HbsIg34elBXPO3QggHjL1En3sjmCPSC5LqucwT3YXjnfsamlITY/jQ8yE1TcGp5UWwHLLWz2skAkiXh82TcT9lGCPOFnTJ8ZeupSbIUyNXH9OjTzRNZuQVZ2W4YOLLrCFtSP5+1rx7QDioZWcvPSWkJqBU2zBB7ksSkEKJ7VJUxBSswP16TNH+7y/y6b7xdJEZ0WrrEDEczdFxEs475Wa4WwjwkHIlxrVcy3Il43kvINNhNTEdpNjkxREdjEzmCuKt+SPa3g2M6sTL9nzSNpFIR7N02HEQ8aCY4NKpGYP+0Md7a/8Ew9ENqH7yGieNRzIQwDx0J6XLMyfzXno4/T0IIWCpAVcng/ebp2pFcAVPNZ/U69Z89xCAPEqZtOfvedh48a6oYvvqmp+COvEtq0cBQD94prjSgmEdWy8BQKIB5UxsY5/tLapefSsM5VY6EsJBuWm1fUhnCNupw3cP7E50Pa/gYsA4kHnrdgRVrLzdj/+lGozn2hd387TOMnmNCmAmYRy07ofTZLfPe5SmIcBqaQcAo5dlQk+8ZDZlOpiK3hYpqJoi4eL1vewZHAQ0qb8C6m5lJJI37TIzbSNxzWCFo5SdVV6xjjwWwjwiQeluNz9w32b56q0itPPvL5vM6MltFuIkQgUoZ/ATMcx3V5Mv903JoBUhHTbU0rfuvvdAnziwRQyFawMjSqcwIMmzsyJdaMKCyCnJe3MEE2EIwTukhb9VMhDv9CD7xYyWNoI17oZWc3bYeVxNvFgOhbcgW/D4nmvMHJ77mxqxPNWqPECv44OewoGEb5MJDfp8KZIlfZny3ZgX4vQUP4M/g8DGdEarK9iEw8GppEAeguJpOMaAZ5j5utF0pdoej8v0TVlyAjKTdIKZ/jGUqCwRh/QhxCZSDGOTTw4C5r8CclhCTtosshhWdJvhRyWBGj1Ux4vITWlKgonkfT4i62fk3qC0xSkGdKkxOBnEg/u/Kaf/P2lvMjxevZnj10EHjS5O39d9Pwanj2WAOl8lF1V0eYHTTg1y4KdWE5JM044V3o9MaL4xINGC22c7vMKPGgHTTja44p5mwIwbYpKnD7SvxzKTYdPmefYwrnKC4wtLT+NeG2oaK7nFkDlxKIWKrNg6P4+wRtAgYCzSOTUCt+W2zemgPZcV3ZFvlvpaSlsCSaDrjUvzE+8AvIQrlqCIsV/wOHc+IIKqG334IXUhBqEe0JEmImd84WOyPnSR4vtvdyBrNny63DYcjO4h3iFIYpornMgKQFgvVqcTCUP4PDN3dqQmlhHNF1g2ya1XdjDB6y8lv0CPRahF6CJV8zvLE7Pojzbub60xokWibt6Wlrl9UtqMMLt2pgQITWR6gjlpqFTpgoQL21oZJywth5uALAtNFtLDpoxSDfH7iwpreK20KMBGQv67iGkJmIwpG/qvQnKsjgoTx3+98tbsaA4+xOTcr3uOilqGnYXRVu+qvQpooUuBkW+Jv42l9wUCggnIIBi1wreR4f0sqHAINzZcJ2D098OGKPT1r1Y5JoJAeWm7lITf/ZPSFVuOT2NjL58scmyFev8CYN4872iOY4kM78BcOq0kyFCauoGN/x0/Eub/CsB5QledI4NBreyU+SR2BioG4d7P6fQYAjQWS/sIRO6pv5dUG7imRYLwcsWasEkix6d9HQn9Io9mrVL8Yk3R88aPT7+tG1sl197zAJY7BIxmZCahvYBdRxsHF0SvRCQnPY7tdOwxeCy3pKoEa/kBup0R6DdLow641xTMxUWoxlTnYRU/QtDUNU/C6CxgHhGSE3TZwS/mPrB4xtTXg3J0/gEsussHW95mOMkRHm+M8BVWql+34PqbYYgrN6mBS3bJ1qPt0KfElTZRU8e35gq7AeENC54888qFcUreLq9h3jL92rnMLa1rw2tdBuAWlClWxvg4IGeKKQmkaAJ5SZUUAfmn0yoPG20yaAMYHtWaEJ55llnBvEyhnccq0Ir1JhmIlKNaWgsAzOrYvxFwjIpoo6fU11UhNcogOfQlgPMeAM9TJcGjCoKIe/4z6/uTqZOSV2T0v2g3FS8mgbRXTIN5NjpzfAU0ipJYmNyj59wiYd3DqiErXCvAjP4F+teBZS0KKdUSE2yKACUm2qhijwGp29sIp8z9SDsLiOd/ImKyK3NwiYeDq6A/kNvNLl/WZZW+fPhJUa0G02gf1hKpIpOGwjwgDoRLfjR5eAC3hnPOMg3C7WGa1DziacF9eUkhN0ldP+qEl5uPeZbtLuEoMYlp0zomrSnC8pNKVe3XE+gTi2LQjMYzFWQSFZ2aZYA4mk1mVP5E3SL1wdMCKt51Jtot3hBTS9NnC44vxnKzRzriSVAAh/pRsHSy7S6/KuDaM4jHvYTSJkdcH/em56K6U6jjXZ/Hhy3MHQq2lfYn/gl/iTWrosvVFlpS30dLVVF81glXjX+ob0g4mGlJTX3+DdXPplJ0E5ZeBxax98GKAWFnSMEnE0ph08IW/vUwi4KYGOxLQqtKDl+/W/nkEwEEQ9XeZJSnXtn7C5xsMFte8e6MxbmIydRHp8MhHIz2ZvSwKDDNwaMASuJtStJoIhMRuk41akjjHg5ujnztuZb4rSr5xRtpNua88awhdS0y0DwQDKdgpwu3xioxWPft7TUCOBCS5LSPUfHLGNkEA8rnGqAx+evpfLMM8EE483p8up+6O/0uVZ7nq4bsIBnvZbTJWSIfaau9CdEqMDhG4P+S7u2r6mcipP3wErhIYx4uHlgCucFedj1a+40zGnD9muOHf1DBbkdOxLURhxjwT5qRecjX/8GAom3TiIgXSPgK5I3schYOKYq6p82gCcWWWfplDt8Y3CFcAczx1HSZeLEY6U2EUPkEA95eOwFFkg8k9UHAmsErArtM8Xu5AqbQbmZlw5S1zcf4nfYgTLaUtMz+XdQukkg8VA2BjfnW+CVJt7XpABCUozk2nf5oaBdNJbL1uUbm7CnUovSLDg7Yduw0qmBxBsEtof4Vs6D+1EulZpuGQWeuGH5xuCe4hmOZu7dpPpwWJrQFxLvO/c8pONtp8qHW+OCzFodMT4Z5hz4bi/QLiM9PGQMyEAgMZDYtJZYpvGd2qb0jyyRUsKdiwLl5p5gFafPGBLPm7qHE8oSuKrVUUAP+zMnkMISWDlrJTsvGqBXXfhofSYVeOJA5GI5E4Og69ef1k7c/BaaHBtIPGQqhBYmX8HDEg+aQ38BX+Z503zEyauQmfzB8KJxHC+4Vngg8YI+Xke4bzMmTEr49qWW8cQvZ3ukEPjjOvpFmJ462ATCiIdToFRW3P30ZXZ7/uhLbgiNKkSFwUf+Ldsgnps3kAHAiKjqwmDM+xDL+LzEo5XNaaleqpXLtUZ95qGFEc/7GlVzCc0y9lZwzxD0dvuuMDEYt2XprB1asziMeKi1WFt3ZaVFlutv7g6CIulxgQtrbHEEmyE3PROE2nIy1vXSOQERBeN9PhMROwYSqfleR7a3L2n67g8/hyUyJtpMMR7RnvD5AzGnciihXxgddOQ/4DqajPYtyRlho3JcyZfyfvK2LNry6s8eS3D8/h7HFNROO3J0O01u+jQ0zePMKfehS+aQo5D8W7wyehB4uUj2TcObkdrMzNtc4Km2uGyvFsOg0EIxnNiLJje9dhg+DHTt195NhTbgYkn+/Xl68lhyNP6NqIoZ8fbz/ecGTxqzgA0r1iNbYY9oStGDj3rEbRwBdafZN1caUmc5rr+U06QWL07wLM16rzRmAOnKPA8DkmoM7f8UT9KR+xYco1jEEmznNJ94mnBOZPMjXQma+3YfoDd0vQykJZCM4il2yLBlHJrTo+RbY3vTA71tSnEu9Zi3NWdG1/gFwiJ5IaM80Sxv2HsMXwz8ghUe4Qg0owbENq1AtoAvTd/4GHvlEqx70jMFvaJIugafKdpFi/JoB03W30rBhPHODSNRy/P5m/y0bRQPayEB3jZcLcwkJMzmJPHy/QetbyVySNpFczZHO2iSAtip3HtggNxk+o2JaMHWaW6vkC8Wi/l2azzQ9sWFuNN5b7tTYLA5dlbqxCu2uwNNXs7xT0nXryRehPtMwVJlawXqEW5eF0U9Kx6SgVAVG896g3GL2Mmq8xVQOTzVmw+GuRSD5oHxs2gE+qEzGxrBhbxp4CiEu5w4D/IsAT93Skk49iNUnNUCmYBnqZe0pC/cAnO0hsrDKeLONzKzIVpwHN7aEOU2U2lXjdmPSNkUkCtHmW8kgMqrO8oAYNeH9mY+nOq325Omgk8vZNceg9X5ozixJSUCbmBKHwmJXo6MS2gp4GLTQ1szlKS3MvGIun+Uke7JBwup+vciF0fDE65gQnxJSE55KjfDchQcjCRwoG9ntkrFKNtkNeI1Sat2SrCe+xRkWL1NUfe/HKvAo1Dkg7hITEDgm6pu2dkkNJE8reogx04w8R6aXav5bmbSugOsoZVu728XIYjbWGa/CKAFeH9TbmWfNQYvm1gmtGeLuu7pFYuWdIYtBg/bHJxODq4Gwy6lrALs1jXqeeQbqjHNMyn4IQg/8qeXl5cTroWeYDiZP3MTGCdNUN1r6trhZc5pcoy0ilPXV/2glRaG4xLSOD2h9C+v7v4DMDfLhrlKJdcfdwoc87I66vYX7YfjTjtiiVoS+zPFfN5DkCvcq7DBp+J+rj8uFcjah48aoTeabPD5+HtyMX16ZJAi7C6hDX4Ugm7x2uCHIeD+vA1+Gt7ZN1du8PPAvTN2g58I5m3NG/xI7E5n2dfbrzratYEF/wPFOCcI8KI0sAAAAABJRU5ErkJggg==
+    mediatype: image/png
   install:
     spec:
       deployments: null
@@ -44,7 +107,8 @@ spec:
   maintainers:
   - email: abhinav.garg@domain.com
     name: Abhinav Garg
-  maturity: alpha
+  maturity: stable
+  minKubeVersion: 1.34.0
   provider:
     name: Weights & Biases
     url: https://wandb.ai

--- a/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -90,8 +90,8 @@ spec:
   - name: Weights & Biases Documentation
     url: https://docs.wandb.ai/
   maintainers:
-  - email: abhinav.garg@domain.com
-    name: Abhinav Garg
+  - email: dpanzella@coreweave.com
+    name: Daniel Panzella
   maturity: stable
   minKubeVersion: 1.34.0
   provider:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -2,26 +2,9 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - bases/operator.clusterserviceversion.yaml
-- ../default
-- ../samples
+- ../olm
+- ../olm/samples
 - ../scorecard
 
-# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
-# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
-# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
-#- target:
-#    group: apps
-#    version: v1
-#    kind: Deployment
-#    name: controller-manager
-#    namespace: system
-#  patch: |-
-#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/containers/1/volumeMounts/0
-#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
-#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
-#    - op: remove
-#      path: /spec/template/spec/volumes/0
+# [WEBHOOK] cert-manager CRs are omitted from config/olm. OLM injects
+# serving certs; do not add a cert Secret volume on the manager Deployment.

--- a/config/olm/community/dependencies.yaml
+++ b/config/olm/community/dependencies.yaml
@@ -1,0 +1,17 @@
+dependencies:
+  - type: olm.package
+    value:
+      packageName: redis-operator
+      version: ">=0.15.0"
+  - type: olm.package
+    value:
+      packageName: clickhouse
+      version: ">=0.26.3"
+  - type: olm.package
+    value:
+      packageName: grafana-operator
+      version: ">=5.21.0"
+  - type: olm.package
+    value:
+      packageName: victoriametrics-operator
+      version: ">=0.66.3"

--- a/config/olm/community/dependencies.yaml
+++ b/config/olm/community/dependencies.yaml
@@ -1,10 +1,6 @@
 dependencies:
   - type: olm.package
     value:
-      packageName: redis-operator
-      version: ">=0.15.0"
-  - type: olm.package
-    value:
       packageName: clickhouse
       version: ">=0.26.3"
   - type: olm.package

--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -1,0 +1,22 @@
+# OLM-safe install: CRDs, RBAC, manager, webhooks. No cert-manager CRs —
+# OLM injects serving certs and CA bundles itself.
+namespace: operator-system
+namePrefix: operator-
+
+resources:
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- metrics_service.yaml
+
+patches:
+- path: manager_metrics_patch.yaml
+  target:
+    kind: Deployment
+- path: manager_webhook_olm_patch.yaml
+  target:
+    kind: Deployment
+- path: manager_openshift_patch.yaml
+  target:
+    kind: Deployment

--- a/config/olm/manager_metrics_patch.yaml
+++ b/config/olm/manager_metrics_patch.yaml
@@ -1,0 +1,4 @@
+# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8443

--- a/config/olm/manager_openshift_patch.yaml
+++ b/config/olm/manager_openshift_patch.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: OPENSHIFT
+    value: "true"

--- a/config/olm/manager_webhook_olm_patch.yaml
+++ b/config/olm/manager_webhook_olm_patch.yaml
@@ -1,0 +1,12 @@
+# Webhook listen config only. Do not add a cert Secret volume — OLM mounts
+# serving certs at this path when it installs the CSV.
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP

--- a/config/olm/metrics_service.yaml
+++ b/config/olm/metrics_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: operator

--- a/config/olm/samples/apps_v1_weightsandbiases.yaml
+++ b/config/olm/samples/apps_v1_weightsandbiases.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.wandb.com/v1
+kind: WeightsAndBiases
+metadata:
+  name: weightsandbiases-sample-v1
+  labels:
+    app.kubernetes.io/name: weightsandbiases
+    app.kubernetes.io/part-of: wandb-operator
+    app.kubernetes.io/managed-by: olm
+spec:
+  chart: {}
+  values: {}

--- a/config/olm/samples/apps_v2_application.yaml
+++ b/config/olm/samples/apps_v2_application.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps.wandb.com/v2
+kind: Application
+metadata:
+  name: application-sample
+  labels:
+    app.kubernetes.io/name: application
+    app.kubernetes.io/part-of: wandb-operator
+    app.kubernetes.io/managed-by: olm
+spec:
+  kind: Deployment
+  podTemplate:
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.27

--- a/config/olm/samples/apps_v2_weightsandbiases.yaml
+++ b/config/olm/samples/apps_v2_weightsandbiases.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps.wandb.com/v2
+kind: WeightsAndBiases
+metadata:
+  name: weightsandbiases-sample
+  labels:
+    app.kubernetes.io/name: weightsandbiases
+    app.kubernetes.io/instance: weightsandbiases-sample
+    app.kubernetes.io/part-of: wandb-operator
+    app.kubernetes.io/managed-by: olm
+spec:
+  size: small
+  retentionPolicy:
+    onDelete: detach
+  mysql:
+    default:
+      externalMysql:
+        host:
+          name: wandb-mysql
+          key: host
+        port:
+          name: wandb-mysql
+          key: port
+        database:
+          name: wandb-mysql
+          key: database
+        username:
+          name: wandb-mysql
+          key: username
+        password:
+          name: wandb-mysql
+          key: password
+  redis:
+    default:
+      managedRedis:
+        storageSize: 1Gi
+  kafka:
+    managedKafka:
+      storageSize: 10Gi
+      replicas: 1
+  objectStore:
+    default:
+      externalObjectStore:
+        bucket:
+          name: wandb-object-store
+          key: bucket
+        accessKey:
+          name: wandb-object-store
+          key: accessKey
+        secretKey:
+          name: wandb-object-store
+          key: secretKey
+        region:
+          name: wandb-object-store
+          key: region
+  clickhouse:
+    default:
+      managedClickhouse:
+        storageSize: 10Gi
+        replicas: 1

--- a/config/olm/samples/apps_v2_weightsandbiases.yaml
+++ b/config/olm/samples/apps_v2_weightsandbiases.yaml
@@ -31,8 +31,13 @@ spec:
           key: password
   redis:
     default:
-      managedRedis:
-        storageSize: 1Gi
+      externalRedis:
+        host:
+          name: wandb-redis
+          key: host
+        port:
+          name: wandb-redis
+          key: port
   kafka:
     managedKafka:
       storageSize: 10Gi

--- a/config/olm/samples/kustomization.yaml
+++ b/config/olm/samples/kustomization.yaml
@@ -1,0 +1,7 @@
+## Samples included in the OLM bundle alm-examples.
+## Managed MySQL and object store are omitted — Moco and SeaweedFS are
+## not in the community-operators-prod catalog.
+resources:
+- apps_v1_weightsandbiases.yaml
+- apps_v2_weightsandbiases.yaml
+- apps_v2_application.yaml

--- a/hack/scripts/prepare-community-bundle.py
+++ b/hack/scripts/prepare-community-bundle.py
@@ -56,6 +56,44 @@ def set_csv_field(csv_text: str, field: str, value: str) -> str:
     return "\n".join(lines) + "\n"
 
 
+# Catalog redis-operator tops out at 0.15.1 and cannot reconcile the Redis
+# CRs this operator writes. Do not list those GVKs as required — OLM treats
+# required CRDs as install deps and will pull 0.15.1 even without a package dep.
+_REDIS_REQUIRED_CRD_NAMES = {
+    "redis.redis.redis.opstreelabs.in",
+    "redisreplications.redis.redis.opstreelabs.in",
+    "redissentinels.redis.redis.opstreelabs.in",
+}
+
+
+def drop_redis_required_crds(csv_text: str) -> str:
+    lines = csv_text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("    - ") and i + 1 < len(lines):
+            block = [line]
+            j = i + 1
+            while j < len(lines) and (
+                lines[j].startswith("      ") or lines[j].strip() == ""
+            ):
+                block.append(lines[j])
+                j += 1
+            name = ""
+            for entry in block:
+                stripped = entry.strip()
+                if stripped.startswith("name:"):
+                    name = stripped.split(":", 1)[1].strip()
+                    break
+            if name in _REDIS_REQUIRED_CRD_NAMES:
+                i = j
+                continue
+        out.append(line)
+        i += 1
+    return "".join(out)
+
+
 def set_dockerfile_label(dockerfile_text: str, key: str, value: str) -> str:
     label = f"LABEL {key}={value}"
     lines = dockerfile_text.splitlines()
@@ -108,7 +146,8 @@ def main() -> int:
         )
     )
     shutil.copyfile(args.dependencies, bundle / "metadata" / "dependencies.yaml")
-    csv_text = set_csv_field(csvs[0].read_text(), "replaces", args.replaces)
+    csv_text = drop_redis_required_crds(csvs[0].read_text())
+    csv_text = set_csv_field(csv_text, "replaces", args.replaces)
     container_image = args.container_image
     if not container_image:
         for line in csv_text.splitlines():

--- a/hack/scripts/prepare-community-bundle.py
+++ b/hack/scripts/prepare-community-bundle.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Stamp community-operators-prod metadata onto a generated operator-sdk bundle."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+def require_file(path: Path, label: str) -> None:
+    if not path.is_file():
+        print(f"Error: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def set_annotation(annotations_text: str, key: str, value: str) -> str:
+    prefix = f"  {key}:"
+    line = f"  {key}: {value}"
+    lines = annotations_text.splitlines()
+    for i, existing in enumerate(lines):
+        if existing.startswith(prefix):
+            lines[i] = line
+            return "\n".join(lines) + "\n"
+    # Insert after the opening "annotations:" line when present.
+    if lines and lines[0].startswith("annotations:"):
+        lines.insert(1, line)
+        return "\n".join(lines) + "\n"
+    lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def set_indented_field(text: str, indent: str, field: str, value: str) -> str:
+    prefix = f"{indent}{field}:"
+    replacement = f"{indent}{field}: {value}"
+    lines = text.splitlines()
+    for i, existing in enumerate(lines):
+        if existing.startswith(prefix):
+            lines[i] = replacement
+            return "\n".join(lines) + "\n"
+    return text
+
+
+def set_csv_field(csv_text: str, field: str, value: str) -> str:
+    updated = set_indented_field(csv_text, "  ", field, value)
+    if updated != csv_text:
+        return updated
+    # Place before the trailing version field when possible.
+    lines = csv_text.splitlines()
+    for i, existing in enumerate(lines):
+        if existing.startswith("  version:"):
+            lines.insert(i, f"  {field}: {value}")
+            return "\n".join(lines) + "\n"
+    lines.append(f"  {field}: {value}")
+    return "\n".join(lines) + "\n"
+
+
+def set_dockerfile_label(dockerfile_text: str, key: str, value: str) -> str:
+    label = f"LABEL {key}={value}"
+    lines = dockerfile_text.splitlines()
+    prefix = f"LABEL {key}="
+    for i, existing in enumerate(lines):
+        if existing.startswith(prefix):
+            lines[i] = label
+            return "\n".join(lines) + "\n"
+    lines.append(label)
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-dir", required=True, type=Path)
+    parser.add_argument("--dependencies", required=True, type=Path)
+    parser.add_argument("--openshift-versions", required=True)
+    parser.add_argument("--replaces", required=True)
+    parser.add_argument("--stage-dir", required=True, type=Path)
+    parser.add_argument(
+        "--container-image",
+        default="",
+        help="CSV metadata.annotations.containerImage (defaults to the manager image).",
+    )
+    args = parser.parse_args()
+
+    bundle = args.bundle_dir
+    annotations = bundle / "metadata" / "annotations.yaml"
+    dockerfile = bundle / "bundle.Dockerfile"
+    if not dockerfile.is_file():
+        # operator-sdk writes bundle.Dockerfile at the repo root by default.
+        dockerfile = bundle.parent / "bundle.Dockerfile"
+    manifests = bundle / "manifests"
+    require_file(annotations, "bundle annotations")
+    require_file(args.dependencies, "dependencies.yaml")
+    if not manifests.is_dir():
+        print(f"Error: bundle manifests directory not found at {manifests}", file=sys.stderr)
+        return 1
+
+    csvs = list(manifests.glob("*.clusterserviceversion.yaml"))
+    if len(csvs) != 1:
+        print(f"Error: expected one CSV in {manifests}, found {len(csvs)}", file=sys.stderr)
+        return 1
+
+    annotations.write_text(
+        set_annotation(
+            annotations.read_text(),
+            "com.redhat.openshift.versions",
+            args.openshift_versions,
+        )
+    )
+    shutil.copyfile(args.dependencies, bundle / "metadata" / "dependencies.yaml")
+    csv_text = set_csv_field(csvs[0].read_text(), "replaces", args.replaces)
+    container_image = args.container_image
+    if not container_image:
+        for line in csv_text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("image:") and ":" in stripped:
+                container_image = stripped.split("image:", 1)[1].strip()
+                break
+    if container_image:
+        csv_text = set_indented_field(csv_text, "    ", "containerImage", container_image)
+    csvs[0].write_text(csv_text)
+
+    if dockerfile.is_file():
+        dockerfile.write_text(
+            set_dockerfile_label(
+                dockerfile.read_text(),
+                "com.redhat.openshift.versions",
+                args.openshift_versions,
+            )
+        )
+        # Community layout expects bundle.Dockerfile inside the version directory.
+        staged_dockerfile_src = dockerfile
+    else:
+        staged_dockerfile_src = None
+
+    if args.stage_dir.exists():
+        shutil.rmtree(args.stage_dir)
+    args.stage_dir.mkdir(parents=True)
+    shutil.copytree(bundle / "manifests", args.stage_dir / "manifests")
+    shutil.copytree(bundle / "metadata", args.stage_dir / "metadata")
+    tests = bundle / "tests"
+    if tests.is_dir():
+        shutil.copytree(tests, args.stage_dir / "tests")
+    if staged_dockerfile_src is not None:
+        dest = args.stage_dir / "bundle.Dockerfile"
+        text = staged_dockerfile_src.read_text()
+        # Paths in the generated Dockerfile are relative to the repo root
+        # (./bundle/manifests). Rewrite them for the community version dir.
+        text = text.replace("COPY bundle/manifests", "COPY ./manifests")
+        text = text.replace("COPY bundle/metadata", "COPY ./metadata")
+        text = text.replace("COPY bundle/tests/scorecard", "COPY ./tests/scorecard")
+        dest.write_text(text)
+
+    print(f"Staged community bundle at {args.stage_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/olm.mk
+++ b/olm.mk
@@ -1,8 +1,49 @@
+# VERSION defaults to the Helm chart appVersion (no leading v).
+VERSION ?= $(shell sed -n 's/^appVersion: *"\(.*\)"/\1/p' deploy/operator/Chart.yaml)
+CHANNELS ?= stable
+DEFAULT_CHANNEL ?= stable
+BUNDLE_METADATA_OPTS ?= --channels=$(CHANNELS) --default-channel=$(DEFAULT_CHANNEL)
+
+IMAGE_TAG_BASE ?= us-docker.pkg.dev/wandb-production/public/wandb/operator
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+# Root Makefile defaults IMG to controller:latest; use the public image unless overridden.
+ifeq ($(origin IMG),file)
+BUNDLE_CONTROLLER_IMG := $(IMAGE_TAG_BASE):$(VERSION)
+else ifeq ($(IMG),controller:latest)
+BUNDLE_CONTROLLER_IMG := $(IMAGE_TAG_BASE):$(VERSION)
+else
+BUNDLE_CONTROLLER_IMG := $(IMG)
+endif
+
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) --package wandb-operator $(BUNDLE_METADATA_OPTS)
+
+# OpenShift floor from CRC 2.60.1 (OpenShift 4.21.8).
+OPENSHIFT_VERSIONS ?= v4.21
+BUNDLE_REPLACES ?= wandb-operator.v1.21.2
+COMMUNITY_BUNDLE_DIR ?= dist/community-operators/operators/wandb-operator/$(VERSION)
+
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	@command -v operator-sdk >/dev/null 2>&1 || { \
+		echo "Error: operator-sdk is required. Install it from https://sdk.operatorframework.io/docs/installation/"; \
+		exit 1; \
+	}
 	operator-sdk generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(BUNDLE_CONTROLLER_IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
+	printf 'resources:\n- manager.yaml\n' > config/manager/kustomization.yaml
+	operator-sdk bundle validate ./bundle
+
+.PHONY: bundle-community
+bundle-community: bundle ## Stamp community-operators-prod metadata and stage the version directory.
+	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 is required."; exit 1; }
+	python3 hack/scripts/prepare-community-bundle.py \
+		--bundle-dir ./bundle \
+		--dependencies config/olm/community/dependencies.yaml \
+		--openshift-versions $(OPENSHIFT_VERSIONS) \
+		--replaces $(BUNDLE_REPLACES) \
+		--container-image $(BUNDLE_CONTROLLER_IMG) \
+		--stage-dir $(COMMUNITY_BUNDLE_DIR)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/olm.mk
+++ b/olm.mk
@@ -19,7 +19,7 @@ BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) --package wandb-operator
 
 # OpenShift floor from CRC 2.60.1 (OpenShift 4.21.8).
 OPENSHIFT_VERSIONS ?= v4.21
-BUNDLE_REPLACES ?= wandb-operator.v1.21.2
+BUNDLE_REPLACES ?= wandb-operator.v1.22.0
 COMMUNITY_BUNDLE_DIR ?= dist/community-operators/operators/wandb-operator/$(VERSION)
 
 .PHONY: bundle

--- a/olm/docs/OLM_Bundle.md
+++ b/olm/docs/OLM_Bundle.md
@@ -1,134 +1,183 @@
-
 # OLM Bundle Overview
 
-Operator Lifecycle Manager (OLM) has updated the method for storing operator bundles. Bundles are now packaged as container images, which include operator manifests and associated metadata. These images are compliant with OCI (Open Container Initiative) specifications, enabling them to be stored and pulled from any OCI-compliant container registry.
+This repository generates an Operator Lifecycle Manager (OLM) bundle that can
+be submitted to
+[community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+under `operators/wandb-operator/<version>/`.
 
-The operator bundle image is designed as a scratch-based (non-runnable) container image. This bundle is utilized by OLM to install operators in OLM-enabled clusters, ensuring a streamlined and automated deployment process.
+The published 1.x packages (`1.0.0`, `1.21.2`) are the Helm-era operator and
+live in [`olm/olm-catalog/`](../olm-catalog/) as a snapshot. Do not generate
+into that directory. New versions are produced from current sources with
+`make bundle` / `make bundle-community`.
 
-The directory structure for an operator bundle is as follows:
+## Generate the bundle
+
+Requires `operator-sdk`, `kustomize` (`make kustomize` installs it), and
+`python3`.
+
+```bash
+# Uses deploy/operator/Chart.yaml appVersion and the public v2 image.
+make bundle
+
+# Optional overrides
+make bundle VERSION=2.0.0 IMG=us-docker.pkg.dev/wandb-production/public/wandb/operator:2.0.0
+```
+
+This writes `./bundle` (manifests, metadata, scorecard tests) and
+`bundle.Dockerfile` at the repo root, then runs `operator-sdk bundle validate`.
+
+## Stage a community-operators-prod directory
+
+```bash
+make bundle-community
+# or
+make bundle-community VERSION=2.0.0 BUNDLE_REPLACES=wandb-operator.v1.21.2
+```
+
+This stamps community-only metadata onto `./bundle` and copies the result to
+`dist/community-operators/operators/wandb-operator/<VERSION>/`:
+
+| File | Purpose |
+| --- | --- |
+| `manifests/` | CRDs, CSV, RBAC, webhook configs |
+| `metadata/annotations.yaml` | Package `wandb-operator`, channel `stable`, `com.redhat.openshift.versions: v4.21` |
+| `metadata/dependencies.yaml` | OLM package deps (see below) |
+| `tests/scorecard/` | Scorecard config |
+| `bundle.Dockerfile` | Scratch image for the version directory |
+
+`com.redhat.openshift.versions` is `v4.21` (OpenShift 4.21 and later), matching
+CRC 2.60.1 / OpenShift 4.21.8. The CSV `minKubeVersion` is `1.34.0`. The 1.x
+catalog entries stay on older OpenShift catalogs; only this version is 4.21+.
+
+The CSV `replaces` field defaults to `wandb-operator.v1.21.2`. Override
+`BUNDLE_REPLACES` when publishing a later 2.x.
+
+Package-level [`ci.yaml`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/operators/wandb-operator/ci.yaml)
+already exists upstream (`replaces-mode` and reviewers). Do not copy a second
+`ci.yaml` into the version directory.
+
+## Submit a community-operators-prod PR
+
+1. Fork [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod).
+2. Copy the staged directory:
+
+   ```bash
+   cp -R dist/community-operators/operators/wandb-operator/<VERSION> \
+     /path/to/community-operators-prod/operators/wandb-operator/
+   ```
+
+3. Open a PR. Pipeline checks include bundle validation and scorecard.
+
+Typical failures: cert-manager CRs left in manifests, missing
+`com.redhat.openshift.versions`, unresolvable `olm.package` versions, or
+`replaces` not pointing at `wandb-operator.v1.21.2`. If the pipeline does not
+yet publish a 4.21 catalog, the `v4.21` floor may need a brief hold.
+
+## Upgrade from 1.21.2
+
+This bundle replaces `wandb-operator.v1.21.2`. It is a v1→v2 CRD conversion:
+the storage version is v2, conversion/defaulting/validation webhooks are
+required, and OLM must install those webhooks before the new CRD is applied.
+
+## Catalog dependencies
+
+`metadata/dependencies.yaml` declares operators that exist in
+community-operators-prod. Moco and SeaweedFS are omitted (not in the catalog).
+
+```yaml
+dependencies:
+  - type: olm.package
+    value: { packageName: redis-operator, version: ">=0.15.0" }
+  - type: olm.package
+    value: { packageName: clickhouse, version: ">=0.26.3" }
+  - type: olm.package
+    value: { packageName: grafana-operator, version: ">=5.21.0" }
+  - type: olm.package
+    value: { packageName: victoriametrics-operator, version: ">=0.66.3" }
+```
+
+OLM installs these when the wandb-operator Subscription is created. Grafana
+and VictoriaMetrics are optional Helm chart deps (telemetry); they are
+required OLM deps so a catalog install always pulls them.
+
+### Redis catalog vs Helm
+
+The Helm chart pins redis-operator **0.22.2**. OpenShift
+community-operators-prod currently maxes out at **0.15.1** (OperatorHub.io
+has 0.25.0; those are different catalogs). The OLM range is `>=0.15.0`, so a
+catalog install resolves **0.15.1**.
+
+Creating Redis CRs against 0.15.0 / 0.15.1 does **not** fail admission. The
+0.15.x CRDs use structural schemas: fields they do not define are stripped
+and stored without those keys. The wandb-operator apply still returns
+success.
+
+This operator does not set `readOnlyRootFilesystem` today. The 0.15.x
+`spec.securityContext` schema **does** include that field, so if it is added
+later it is applied, not ignored.
+
+| Field this operator writes | 0.15.x Redis / RedisReplication | 0.15.x RedisSentinel |
+| --- | --- | --- |
+| `spec.securityContext` (runAsNonRoot, drop ALL, …) | kept | kept |
+| `spec.securityContext.readOnlyRootFilesystem` (if set) | **applied** | **applied** |
+| `spec.storage.volumeMount` (`/tmp` emptyDir) | kept | n/a (Sentinel has no `storage`) |
+| `spec.volumeMount` (`/tmp` emptyDir) | n/a | **pruned** |
+| `spec.redisExporter.port` | **pruned** | **pruned** |
+| `spec.redisExporter.securityContext` | **pruned** | **pruned** |
+
+**Without RORFS (current code):** standalone and replication stay usable.
+Sentinel HA also runs because the container root FS stays writable, so the
+missing `/tmp` mount does not matter. Telemetry exporters start without the
+intended port (9121) and container security context — redis-operator uses
+its own defaults.
+
+**With RORFS on `spec.securityContext`:** standalone and replication can
+still work because `storage.volumeMount` survives and supplies `/tmp`.
+Sentinel cannot: RORFS is applied and `spec.volumeMount` is dropped, so
+Sentinel pods lose a writable `/tmp` and typically CrashLoop. That is a
+runtime failure, not a CRD validation error.
+
+Pruned fields also make desired ≠ live on every reconcile
+(`resourceContentEqual`), so Sentinel CRs (and any Redis CR with a
+telemetry exporter) are updated on each loop. The update succeeds; the
+unknown fields are stripped again.
+
+0.15.x on OpenShift also has separate upstream RBAC gaps for
+`redisreplications` / `redissentinels` (see
+[OT-CONTAINER-KIT/redis-operator#665](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/665)
+and
+[#1665](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1665)).
+Those can block the redis-operator itself from reconciling HA CRs even
+when wandb-operator writes them successfully.
+
+For RORFS or Sentinel HA, install redis-operator **≥ 0.22.2** out of band,
+or use `spec.redis.default.externalRedis`. Do not rely on the catalog
+0.15.x operator.
+
+### Managed MySQL and object store
+
+Moco and SeaweedFS are not in the catalog. On an OLM-only cluster, use
+`spec.mysql.default.externalMysql` and
+`spec.objectStore.default.externalObjectStore` (and bring your own ingress on
+OpenShift). The bundle sample follows that shape. The generated ClusterRole
+still includes Moco/SeaweedFS verbs so out-of-band installs keep working.
+
+## Directory layout
 
 ```
-$ tree bundle
+$ tree dist/community-operators/operators/wandb-operator/<VERSION>
 
-bundle
-├── ci.yaml
+<VERSION>
+├── bundle.Dockerfile
 ├── manifests
+│   ├── apps.wandb.com_applications.yaml
 │   ├── apps.wandb.com_weightsandbiases.yaml
-│   ├── wandb-operator-manager_rbac.authorization.k8s.io_v1_clusterrole.yaml
-│   ├── wandb-operator-manager_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+│   ├── ...
 │   └── wandb-operator.clusterserviceversion.yaml
 ├── metadata
-│   └── annotations.yaml
+│   ├── annotations.yaml
+│   └── dependencies.yaml
 └── tests
     └── scorecard
         └── config.yaml
-
 ```
-
-Each operator bundle must include a Cluster Service Version (CSV) file. Bundle metadata is stored in `bundle/metadata/annotations.yaml`, which provides essential information about the specific version of the operator available in the registry.
-
-Example content of `annotations.yaml`:
-
-```
-$ cat metadata/annotations.yaml
-
-annotations:
-  com.redhat.openshift.versions: v4.12
-  # Core bundle annotations.
-  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
-  operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: wandb-operator
-  operators.operatorframework.io.bundle.channels.v1: stable
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-
-  # Annotations for testing.
-  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
-  operators.operatorframework.io.test.config.v1: tests/scorecard/
-```
-
-## Building the Operator Bundle Image
-
-You can create a bundle image using the following `Dockerfile`:
-
-```
-$ cat bundle.Dockerfile
-
-FROM scratch
-
-# Core bundle labels.
-LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
-LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=wandb-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-
-# Labels for testing.
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-
-# Copy files to locations specified by labels.
-COPY ./manifests /manifests/
-COPY ./metadata /metadata/
-COPY ./tests/scorecard /tests/scorecard/
-
-LABEL com.redhat.openshift.versions=v4.12
-```
-
-To build the image and push it to a public repository, use the following command:
-
-```
-docker build -f bundle.Dockerfile -t quay.io/wandb_tools/wandb-operator:v1.0.0 .
-```
-
-At this point, you have built the operator bundle image. To integrate it into Red Hat's certification pipeline, you can push the image for Red Hat verification. However, this image is not deployable as a CatalogSource on OpenShift yet.
-
-## Creating a CatalogSource for OpenShift
-
-To deploy the operator on OpenShift, you must create a `CatalogSource` from the bundle image. First, ensure that the `opm` tool is installed.
-
-Run the following command to create the `CatalogSource`:
-
-```
-opm index add --container-tool docker --bundles quay.io/wandb_tools/wandb-operator:v1.0.0  --tag quay.io/wandb_tools/wandb-operator-index:v1.0.0
-```
-
-This will generate an image that can be used as a `CatalogSource`: `quay.io/wandb_tools/wandb-operator-index:v1.0.0`.
-
-### Updating CSVs for New Versions
-
-If you want to replace an old CSV with a new one in your catalog, you can use the following command to include both bundles:
-
-```
-opm index add --container-tool=docker --bundles=quay.io/wandb_tools/wandb-operator:v1.0.0,quay.io/wandb_tools/wandb-operator:v1.0.1 --tag  quay.io/wandb_tools/wandb-operator-index:v1.0.1
-```
-
-This command creates an image (`v1.0.1`) that supersedes the older CSV (`v1.0.0`).
-
-## OLM Catalog Source Upgrade Chain
-
-When managing multiple versions of an operator, it is crucial for OLM to automatically upgrade to the latest version. To achieve this, the `CSV` must include a `replaces` field, indicating which previous CSV version it is replacing.
-
-Consider the following example where the initial version (`v1.0.0`) of the operator is created:
-
-```
-opm index add --container-tool docker --bundles quay.io/wandb_tools/wandb-operator:v1.0.0  --tag quay.io/wandb_tools/wandb-operator-index:v1.0.0
-```
-
-Once a new version (`v1.0.1`) is released, you can specify the `--from-index` option to ensure the upgrade chain links to the previous version:
-
-```
-opm index add --container-tool=docker --bundles=quay.io/wandb_tools/wandb-operator:v1.0.1 --from-index=quay.io/wandb_tools/wandb-operator-index:v1.0.0 --tag quay.io/wandb_tools/wandb-operator-index:v1.0.1
-
-```
-
-This ensures that `v1.0.1` will automatically replace `v1.0.0` when upgrading.
-
-You can continue this process for subsequent versions, and `opm` will manage the version upgrade chain via the `CSV` definitions.

--- a/olm/docs/OLM_Bundle.md
+++ b/olm/docs/OLM_Bundle.md
@@ -31,7 +31,7 @@ This writes `./bundle` (manifests, metadata, scorecard tests) and
 ```bash
 make bundle-community
 # or
-make bundle-community VERSION=2.0.0 BUNDLE_REPLACES=wandb-operator.v1.21.2
+make bundle-community VERSION=2.0.0 BUNDLE_REPLACES=wandb-operator.v1.22.0
 ```
 
 This stamps community-only metadata onto `./bundle` and copies the result to
@@ -49,7 +49,7 @@ This stamps community-only metadata onto `./bundle` and copies the result to
 CRC 2.60.1 / OpenShift 4.21.8. The CSV `minKubeVersion` is `1.34.0`. The 1.x
 catalog entries stay on older OpenShift catalogs; only this version is 4.21+.
 
-The CSV `replaces` field defaults to `wandb-operator.v1.21.2`. Override
+The CSV `replaces` field defaults to `wandb-operator.v1.22.0`. Override
 `BUNDLE_REPLACES` when publishing a later 2.x.
 
 Package-level [`ci.yaml`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/operators/wandb-operator/ci.yaml)
@@ -70,12 +70,12 @@ already exists upstream (`replaces-mode` and reviewers). Do not copy a second
 
 Typical failures: cert-manager CRs left in manifests, missing
 `com.redhat.openshift.versions`, unresolvable `olm.package` versions, or
-`replaces` not pointing at `wandb-operator.v1.21.2`. If the pipeline does not
+`replaces` not pointing at `wandb-operator.v1.22.0`. If the pipeline does not
 yet publish a 4.21 catalog, the `v4.21` floor may need a brief hold.
 
-## Upgrade from 1.21.2
+## Upgrade from 1.22.0
 
-This bundle replaces `wandb-operator.v1.21.2`. It is a v1→v2 CRD conversion:
+This bundle replaces `wandb-operator.v1.22.0`. It is a v1→v2 CRD conversion:
 the storage version is v2, conversion/defaulting/validation webhooks are
 required, and OLM must install those webhooks before the new CRD is applied.
 
@@ -86,8 +86,6 @@ community-operators-prod. Moco and SeaweedFS are omitted (not in the catalog).
 
 ```yaml
 dependencies:
-  - type: olm.package
-    value: { packageName: redis-operator, version: ">=0.15.0" }
   - type: olm.package
     value: { packageName: clickhouse, version: ">=0.26.3" }
   - type: olm.package
@@ -100,67 +98,27 @@ OLM installs these when the wandb-operator Subscription is created. Grafana
 and VictoriaMetrics are optional Helm chart deps (telemetry); they are
 required OLM deps so a catalog install always pulls them.
 
-### Redis catalog vs Helm
+Redis is **not** an OLM package dependency. Community-operators-prod maxes
+out at redis-operator **0.15.1**; Helm pins **0.22.2**, and 0.15.x cannot
+reconcile the HA Redis CRs this operator writes (missing
+`redisreplications` / `redissentinels` RBAC, pruned Sentinel fields). The
+CSV therefore does not list Redis GVKs under
+`customresourcedefinitions.required` — OLM treats required CRDs as hard
+install deps, so declaring them still pulled catalog 0.15.1 even after the
+package was dropped.
 
-The Helm chart pins redis-operator **0.22.2**. OpenShift
-community-operators-prod currently maxes out at **0.15.1** (OperatorHub.io
-has 0.25.0; those are different catalogs). The OLM range is `>=0.15.0`, so a
-catalog install resolves **0.15.1**.
-
-Creating Redis CRs against 0.15.0 / 0.15.1 does **not** fail admission. The
-0.15.x CRDs use structural schemas: fields they do not define are stripped
-and stored without those keys. The wandb-operator apply still returns
-success.
-
-This operator does not set `readOnlyRootFilesystem` today. The 0.15.x
-`spec.securityContext` schema **does** include that field, so if it is added
-later it is applied, not ignored.
-
-| Field this operator writes | 0.15.x Redis / RedisReplication | 0.15.x RedisSentinel |
-| --- | --- | --- |
-| `spec.securityContext` (runAsNonRoot, drop ALL, …) | kept | kept |
-| `spec.securityContext.readOnlyRootFilesystem` (if set) | **applied** | **applied** |
-| `spec.storage.volumeMount` (`/tmp` emptyDir) | kept | n/a (Sentinel has no `storage`) |
-| `spec.volumeMount` (`/tmp` emptyDir) | n/a | **pruned** |
-| `spec.redisExporter.port` | **pruned** | **pruned** |
-| `spec.redisExporter.securityContext` | **pruned** | **pruned** |
-
-**Without RORFS (current code):** standalone and replication stay usable.
-Sentinel HA also runs because the container root FS stays writable, so the
-missing `/tmp` mount does not matter. Telemetry exporters start without the
-intended port (9121) and container security context — redis-operator uses
-its own defaults.
-
-**With RORFS on `spec.securityContext`:** standalone and replication can
-still work because `storage.volumeMount` survives and supplies `/tmp`.
-Sentinel cannot: RORFS is applied and `spec.volumeMount` is dropped, so
-Sentinel pods lose a writable `/tmp` and typically CrashLoop. That is a
-runtime failure, not a CRD validation error.
-
-Pruned fields also make desired ≠ live on every reconcile
-(`resourceContentEqual`), so Sentinel CRs (and any Redis CR with a
-telemetry exporter) are updated on each loop. The update succeeds; the
-unknown fields are stripped again.
-
-0.15.x on OpenShift also has separate upstream RBAC gaps for
-`redisreplications` / `redissentinels` (see
-[OT-CONTAINER-KIT/redis-operator#665](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/665)
-and
-[#1665](https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1665)).
-Those can block the redis-operator itself from reconciling HA CRs even
-when wandb-operator writes them successfully.
-
-For RORFS or Sentinel HA, install redis-operator **≥ 0.22.2** out of band,
-or use `spec.redis.default.externalRedis`. Do not rely on the catalog
-0.15.x operator.
+On an OLM-only cluster, use `spec.redis.default.externalRedis`. For managed
+Redis, install redis-operator **≥ 0.22.2** out of band. The generated
+ClusterRole still includes Redis verbs so that optional install works.
 
 ### Managed MySQL and object store
 
 Moco and SeaweedFS are not in the catalog. On an OLM-only cluster, use
 `spec.mysql.default.externalMysql` and
 `spec.objectStore.default.externalObjectStore` (and bring your own ingress on
-OpenShift). The bundle sample follows that shape. The generated ClusterRole
-still includes Moco/SeaweedFS verbs so out-of-band installs keep working.
+OpenShift). The bundle sample follows that shape, including external Redis.
+The generated ClusterRole still includes Moco/SeaweedFS verbs so out-of-band
+installs keep working.
 
 ## Directory layout
 


### PR DESCRIPTION
- Adds script and makefile to generate OLM bundle
- Matches formatting for community-operators repository
- Tested and bundle is generated cleanly

## Dependencies this OLM bundle omits
- Moco
  - Not available in the OLM catalog
- Seaweedfs
  - Not available in the OLM catalog
- redis-operator
  - Our helm chart requires 0.22.2, but only 0.15.1 is available in the OLM catalog
  - There are compatibility issues with setting volumeMounts to enable `readOnlyRootFilesystem`. This isn't implemented now, but it will be and it's easier to just omit it entirely
