### PR TITLE
fix: Watchtower-docker-use-gh-release

### DIFF
--- a/.github/workflows/docker-build-scan.yml
+++ b/.github/workflows/docker-build-scan.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
-    # The build pulls the Watchtower binary from the private wandb/watchtower
-    # releases, which needs an App token. Fork PRs get no secrets, so this job
-    # can't run for them; pull_request_target is not an option here because it
-    # would expose the token to the fork's Dockerfile.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/docker-build-scan.yml
+++ b/.github/workflows/docker-build-scan.yml
@@ -30,6 +30,11 @@ jobs:
           owner: wandb
           repositories: watchtower
 
+      - name: Download the Watchtower binary
+        env:
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
+        run: make download-watchtower
+
       - name: Build Docker image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -39,8 +44,6 @@ jobs:
           tags: wandb/operator:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            gh_token=${{ steps.watchtower-token.outputs.token }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master

--- a/.github/workflows/docker-build-scan.yml
+++ b/.github/workflows/docker-build-scan.yml
@@ -9,12 +9,26 @@ on:
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
+    # The build pulls the Watchtower binary from the private wandb/watchtower
+    # releases, which needs an App token. Fork PRs get no secrets, so this job
+    # can't run for them; pull_request_target is not an option here because it
+    # would expose the token to the fork's Dockerfile.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Mint a token to read wandb/watchtower releases
+        id: watchtower-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WESTEST_APP_ID }}
+          private-key: ${{ secrets.WESTEST_APP_PRIVATE_KEY }}
+          owner: wandb
+          repositories: watchtower
 
       - name: Build Docker image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -25,6 +39,8 @@ jobs:
           tags: wandb/operator:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            gh_token=${{ steps.watchtower-token.outputs.token }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master

--- a/.github/workflows/internal-image-publish.yaml
+++ b/.github/workflows/internal-image-publish.yaml
@@ -58,9 +58,13 @@ jobs:
           owner: wandb
           repositories: watchtower
 
+      - name: Download the Watchtower binary
+        env:
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
+        run: make download-watchtower
+
       - name: Build and publish development image
         env:
           IMAGE_REPOSITORY: us-docker.pkg.dev/wandb-production/public/wandb/operator
           VERSION: ${{ inputs.image_tag }}
-          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${VERSION}"

--- a/.github/workflows/internal-image-publish.yaml
+++ b/.github/workflows/internal-image-publish.yaml
@@ -47,8 +47,20 @@ jobs:
       - name: Authorize Docker for Artifact Registry
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
+      - name: Mint a token to read wandb/watchtower releases
+        id: watchtower-token
+        # The image build downloads the Watchtower binary from that private repo;
+        # this repo's GITHUB_TOKEN can't reach it.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WESTEST_APP_ID }}
+          private-key: ${{ secrets.WESTEST_APP_PRIVATE_KEY }}
+          owner: wandb
+          repositories: watchtower
+
       - name: Build and publish development image
         env:
           IMAGE_REPOSITORY: us-docker.pkg.dev/wandb-production/public/wandb/operator
           VERSION: ${{ inputs.image_tag }}
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${VERSION}"

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -96,9 +96,21 @@ jobs:
           # yq v4 is preinstalled on ubuntu-latest.
           yq -i '.["wandb-operator"].image.tag = strenv(IMAGE_TAG)' deploy/operator/values.yaml
 
+      - name: Mint a token to read wandb/watchtower releases
+        id: watchtower-token
+        # The image build downloads the Watchtower binary from that private repo;
+        # this repo's GITHUB_TOKEN can't reach it.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WESTEST_APP_ID }}
+          private-key: ${{ secrets.WESTEST_APP_PRIVATE_KEY }}
+          owner: wandb
+          repositories: watchtower
+
       - name: Build and push nightly image
         env:
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
 
       - name: Resolve chart dependencies

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -107,10 +107,14 @@ jobs:
           owner: wandb
           repositories: watchtower
 
+      - name: Download the Watchtower binary
+        env:
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
+        run: make download-watchtower
+
       - name: Build and push nightly image
         env:
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
-          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
 
       - name: Resolve chart dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,10 +151,14 @@ jobs:
           owner: wandb
           repositories: watchtower
 
+      - name: Download the Watchtower binary
+        env:
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
+        run: make download-watchtower
+
       - name: Build and publish image
         env:
           VERSION: ${{ steps.release.outputs.version }}
-          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${VERSION}"
 
       - name: Install chart-testing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,9 +140,21 @@ jobs:
       #          assert_absent "${IMAGE_REPOSITORY}:${VERSION}"
       #          assert_absent "${CHART_REPOSITORY}/operator:${VERSION}"
 
+      - name: Mint a token to read wandb/watchtower releases
+        id: watchtower-token
+        # The image build downloads the Watchtower binary from that private repo;
+        # this repo's GITHUB_TOKEN can't reach it.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WESTEST_APP_ID }}
+          private-key: ${{ secrets.WESTEST_APP_PRIVATE_KEY }}
+          owner: wandb
+          repositories: watchtower
+
       - name: Build and publish image
         env:
           VERSION: ${{ steps.release.outputs.version }}
+          GH_TOKEN: ${{ steps.watchtower-token.outputs.token }}
         run: make docker-build docker-push IMG="${IMAGE_REPOSITORY}:${VERSION}"
 
       - name: Install chart-testing

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ hack/testing-manifests/wandb/.generated/*.yaml
 
 # various util artifacts
 .k8s-images
+
+# Downloaded by `make download-watchtower` for the image build
+/watchtower

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
 # Watchtower ships in this image as a second entrypoint: the operator synthesizes
 # an Application that runs the same image with `command: ["/watchtower"]`, and
 # finds this image by name through OPERATOR_IMAGE. Its binary embeds a Next.js
-# static export, so it cannot be rebuilt from Go source here — download the
-# published binary instead.
+# static export, so it cannot be rebuilt from Go source here.
 #
-# Watchtower no longer publishes a container image; it attaches per-arch Linux
-# binaries to its GitHub Release. wandb/watchtower is a PRIVATE repository, so the
-# fetch below needs a token with read access, passed as a BuildKit secret:
-#
-#   GH_TOKEN=$(gh auth token) \
-#     docker build --secret id=gh_token,env=GH_TOKEN .
-#
-# The tag carries its leading "v" — it is the release tag verbatim, not the de-v'ed
-# form the old image tag used.
-ARG WATCHTOWER_VERSION=v0.12.0-rc.1
+# This build does NOT download it. Run `make download-watchtower` first — that
+# pulls the binary for the target arch out of the private wandb/watchtower GitHub
+# Release into the repo root, and this build only copies the result.
 
 # Build the manager binary
 FROM golang:1.26 AS manager-builder
@@ -43,42 +35,14 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/manager
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o crd-installer ./cmd/crd-installer
 
-# A private repo's assets are not reachable by their browser download URL — that
-# 404s even with a token. The releases API has to resolve the asset id first, then
-# serve the bytes with Accept: application/octet-stream.
-FROM alpine:3.21 AS watchtower
-ARG WATCHTOWER_VERSION
-ARG TARGETARCH
-RUN apk add --no-cache ca-certificates curl jq tar
-RUN --mount=type=secret,id=gh_token \
-    set -eu; \
-    token="$(cat /run/secrets/gh_token)"; \
-    api="https://api.github.com/repos/wandb/watchtower"; \
-    asset="watchtower-linux-${TARGETARCH}.tar.gz"; \
-    release="$(curl -fsSL -H "Authorization: Bearer ${token}" \
-                 "${api}/releases/tags/${WATCHTOWER_VERSION}")"; \
-    fetch() { \
-      id="$(printf '%s' "${release}" | jq -r --arg n "$1" '.assets[] | select(.name == $n) | .id')"; \
-      if [ -z "${id}" ] || [ "${id}" = "null" ]; then \
-        echo "release ${WATCHTOWER_VERSION} has no asset named $1" >&2; \
-        return 1; \
-      fi; \
-      curl -fsSL -H "Authorization: Bearer ${token}" -H "Accept: application/octet-stream" \
-        -o "/tmp/$1" "${api}/releases/assets/${id}"; \
-    }; \
-    fetch "${asset}"; \
-    fetch watchtower-linux-checksums.txt; \
-    cd /tmp && grep "${asset}" watchtower-linux-checksums.txt | sha256sum -c -; \
-    tar -xzf "/tmp/${asset}" -C /
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 WORKDIR /
 COPY --from=manager-builder /workspace/manager .
 COPY --from=manager-builder /workspace/crd-installer .
-# Released CGO-free and statically linked, so it runs unmodified on this glibc
-# base despite having been unpacked in an Alpine stage.
-COPY --from=watchtower /watchtower .
+# Released CGO-free and statically linked, so it runs unmodified on this glibc base.
+# Produced by `make download-watchtower`, not by this build.
+COPY watchtower /watchtower
 
 RUN mkdir -p /helm/.cache/helm /helm/.config/helm /helm/.local/share/helm && \
     chown -R 65532:65532 /helm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 # Watchtower ships in this image as a second entrypoint: the operator synthesizes
 # an Application that runs the same image with `command: ["/watchtower"]`, and
 # finds this image by name through OPERATOR_IMAGE. Its binary embeds a Next.js
-# static export, so it cannot be rebuilt from Go source here — lift the binary out
-# of the published Watchtower image instead.
-ARG WATCHTOWER_IMAGE=us-docker.pkg.dev/wandb-production/public/wandb/watchtower
-ARG WATCHTOWER_VERSION=0.11.0
+# static export, so it cannot be rebuilt from Go source here — download the
+# published binary instead.
+#
+# Watchtower no longer publishes a container image; it attaches per-arch Linux
+# binaries to its GitHub Release. wandb/watchtower is a PRIVATE repository, so the
+# fetch below needs a token with read access, passed as a BuildKit secret:
+#
+#   GH_TOKEN=$(gh auth token) \
+#     docker build --secret id=gh_token,env=GH_TOKEN .
+#
+# The tag carries its leading "v" — it is the release tag verbatim, not the de-v'ed
+# form the old image tag used.
+ARG WATCHTOWER_VERSION=v0.12.0-rc.1
 
 # Build the manager binary
 FROM golang:1.26 AS manager-builder
@@ -34,14 +43,41 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/manager
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o crd-installer ./cmd/crd-installer
 
-FROM ${WATCHTOWER_IMAGE}:${WATCHTOWER_VERSION} AS watchtower
+# A private repo's assets are not reachable by their browser download URL — that
+# 404s even with a token. The releases API has to resolve the asset id first, then
+# serve the bytes with Accept: application/octet-stream.
+FROM alpine:3.21 AS watchtower
+ARG WATCHTOWER_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache ca-certificates curl jq tar
+RUN --mount=type=secret,id=gh_token \
+    set -eu; \
+    token="$(cat /run/secrets/gh_token)"; \
+    api="https://api.github.com/repos/wandb/watchtower"; \
+    asset="watchtower-linux-${TARGETARCH}.tar.gz"; \
+    release="$(curl -fsSL -H "Authorization: Bearer ${token}" \
+                 "${api}/releases/tags/${WATCHTOWER_VERSION}")"; \
+    fetch() { \
+      id="$(printf '%s' "${release}" | jq -r --arg n "$1" '.assets[] | select(.name == $n) | .id')"; \
+      if [ -z "${id}" ] || [ "${id}" = "null" ]; then \
+        echo "release ${WATCHTOWER_VERSION} has no asset named $1" >&2; \
+        return 1; \
+      fi; \
+      curl -fsSL -H "Authorization: Bearer ${token}" -H "Accept: application/octet-stream" \
+        -o "/tmp/$1" "${api}/releases/assets/${id}"; \
+    }; \
+    fetch "${asset}"; \
+    fetch watchtower-linux-checksums.txt; \
+    cd /tmp && grep "${asset}" watchtower-linux-checksums.txt | sha256sum -c -; \
+    tar -xzf "/tmp/${asset}" -C /
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 WORKDIR /
 COPY --from=manager-builder /workspace/manager .
 COPY --from=manager-builder /workspace/crd-installer .
-# Built CGO-free on golang:alpine, so it runs unmodified on this glibc base.
+# Released CGO-free and statically linked, so it runs unmodified on this glibc
+# base despite having been unpacked in an Alpine stage.
 COPY --from=watchtower /watchtower .
 
 RUN mkdir -p /helm/.cache/helm /helm/.config/helm /helm/.local/share/helm && \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 IMG ?= controller:latest
 
 # Watchtower release whose binary is copied into the operator image as its second
-# entrypoint. Must be a tag that exists in WATCHTOWER_IMAGE — the build pulls it.
-WATCHTOWER_IMAGE ?= us-docker.pkg.dev/wandb-production/public/wandb/watchtower
-WATCHTOWER_VERSION ?= 0.11.0
+# entrypoint. Tag verbatim, leading "v" included. Fetching it needs GH_TOKEN — see
+# the comment at the top of the Dockerfile.
+WATCHTOWER_VERSION ?= v0.12.0-rc.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -214,9 +214,14 @@ run: manifests generate fmt vet ## Run the manager from your host.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: ## Build controller docker image.
-	$(CONTAINER_TOOL) build --platform linux/amd64 \
-		--build-arg WATCHTOWER_IMAGE=$(WATCHTOWER_IMAGE) \
+docker-build: ## Build controller docker image. Requires GH_TOKEN with read access to wandb/watchtower.
+	@if [ -z "$${GH_TOKEN:-}" ]; then \
+		echo "GH_TOKEN is required: the build downloads the Watchtower binary from the private wandb/watchtower releases." >&2; \
+		echo "Locally: GH_TOKEN=\$$(gh auth token) make docker-build" >&2; \
+		exit 1; \
+	fi
+	DOCKER_BUILDKIT=1 $(CONTAINER_TOOL) build --platform linux/amd64 \
+		--secret id=gh_token,env=GH_TOKEN \
 		--build-arg WATCHTOWER_VERSION=$(WATCHTOWER_VERSION) \
 		-t ${IMG} -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 IMG ?= controller:latest
 
 # Watchtower release whose binary is copied into the operator image as its second
-# entrypoint. Tag verbatim, leading "v" included. Fetching it needs GH_TOKEN — see
-# the comment at the top of the Dockerfile.
+# entrypoint. Tag verbatim, leading "v" included. `make download-watchtower`
+# fetches it into WATCHTOWER_BINARY; the image build only copies that file.
 WATCHTOWER_VERSION ?= v0.12.0-rc.1
+# The binary is arch-specific, so this also drives the image platform below.
+WATCHTOWER_ARCH ?= amd64
+WATCHTOWER_BINARY ?= watchtower
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -210,19 +213,55 @@ build-crd-installer: ## Build the crd-installer binary.
 run: manifests generate fmt vet ## Run the manager from your host.
 	go run ./cmd/manager
 
+# wandb/watchtower is private and no longer publishes a container image, so the
+# binary comes from its GitHub Release. A private repo's assets are not reachable
+# by their browser download URL — that 404s even with a token — so the release API
+# has to resolve the asset id first, then serve the bytes with
+# Accept: application/octet-stream.
+.PHONY: download-watchtower
+download-watchtower: ## Download the Watchtower binary into the repo root. Requires GH_TOKEN with read access to wandb/watchtower.
+	@command -v curl >/dev/null 2>&1 || { echo "curl is required but was not found." >&2; exit 1; }
+	@command -v jq >/dev/null 2>&1 || { echo "jq is required but was not found." >&2; exit 1; }
+	@if [ -z "$${GH_TOKEN:-}" ]; then \
+		echo "GH_TOKEN is required: wandb/watchtower is a private repository." >&2; \
+		echo "Locally: GH_TOKEN=\$$(gh auth token) make download-watchtower" >&2; \
+		exit 1; \
+	fi
+	@set -eu; \
+	api="https://api.github.com/repos/wandb/watchtower"; \
+	asset="watchtower-linux-$(WATCHTOWER_ARCH).tar.gz"; \
+	checksums="watchtower-linux-checksums.txt"; \
+	tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	echo "Fetching $$asset from wandb/watchtower $(WATCHTOWER_VERSION)"; \
+	release="$$(curl -fsSL -H "Authorization: Bearer $$GH_TOKEN" \
+		"$$api/releases/tags/$(WATCHTOWER_VERSION)")"; \
+	for name in "$$asset" "$$checksums"; do \
+		id="$$(printf '%s' "$$release" | jq -r --arg n "$$name" '.assets[] | select(.name == $$n) | .id')"; \
+		if [ -z "$$id" ] || [ "$$id" = "null" ]; then \
+			echo "release $(WATCHTOWER_VERSION) has no asset named $$name" >&2; \
+			exit 1; \
+		fi; \
+		curl -fsSL -H "Authorization: Bearer $$GH_TOKEN" -H "Accept: application/octet-stream" \
+			-o "$$tmp/$$name" "$$api/releases/assets/$$id"; \
+	done; \
+	if command -v sha256sum >/dev/null 2>&1; then sha="sha256sum"; else sha="shasum -a 256"; fi; \
+	(cd "$$tmp" && grep "$$asset" "$$checksums" | $$sha -c -); \
+	tar -xzf "$$tmp/$$asset" -C "$$tmp"; \
+	mv "$$tmp/watchtower" "$(WATCHTOWER_BINARY)"; \
+	chmod 0755 "$(WATCHTOWER_BINARY)"; \
+	echo "Wrote $(WATCHTOWER_BINARY) (linux/$(WATCHTOWER_ARCH))"
+
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: ## Build controller docker image. Requires GH_TOKEN with read access to wandb/watchtower.
-	@if [ -z "$${GH_TOKEN:-}" ]; then \
-		echo "GH_TOKEN is required: the build downloads the Watchtower binary from the private wandb/watchtower releases." >&2; \
-		echo "Locally: GH_TOKEN=\$$(gh auth token) make docker-build" >&2; \
+docker-build: ## Build controller docker image. Run download-watchtower first.
+	@if [ ! -f "$(WATCHTOWER_BINARY)" ]; then \
+		echo "$(WATCHTOWER_BINARY) not found: run 'GH_TOKEN=\$$(gh auth token) make download-watchtower' first." >&2; \
 		exit 1; \
 	fi
-	DOCKER_BUILDKIT=1 $(CONTAINER_TOOL) build --platform linux/amd64 \
-		--secret id=gh_token,env=GH_TOKEN \
-		--build-arg WATCHTOWER_VERSION=$(WATCHTOWER_VERSION) \
+	$(CONTAINER_TOOL) build --platform linux/$(WATCHTOWER_ARCH) \
 		-t ${IMG} -f Dockerfile .
 
 .PHONY: docker-push


### PR DESCRIPTION
Use github release tag instead of gcr image in watchtower dockerfile