### PR TITLE
fix: normalize 2xlarge size spelling

### DIFF
--- a/api/v1/weightsandbiases_conversion_mapping.go
+++ b/api/v1/weightsandbiases_conversion_mapping.go
@@ -58,7 +58,8 @@ var validSizes = map[string]appsv2.Size{
 	string(appsv2.SizeMedium):  appsv2.SizeMedium,
 	string(appsv2.SizeLarge):   appsv2.SizeLarge,
 	string(appsv2.SizeXLarge):  appsv2.SizeXLarge,
-	string(appsv2.SizeXXLarge): appsv2.SizeXXLarge,
+	string(appsv2.Size2XLarge): appsv2.Size2XLarge,
+	string(appsv2.SizeXXLarge): appsv2.Size2XLarge,
 }
 
 // applyValueMappings is the top-level conversion orchestrator. It resolves

--- a/api/v1/weightsandbiases_conversion_overrides.go
+++ b/api/v1/weightsandbiases_conversion_overrides.go
@@ -377,6 +377,7 @@ func legacyResourcesFromSection(section map[string]interface{}, sectionName, glo
 	if size == "" {
 		size = legacyDefaultSize
 	}
+	size = string(appsv2.Size(size).Canonical())
 
 	merged := map[string]interface{}{}
 	for _, path := range [][]string{

--- a/api/v1/weightsandbiases_conversion_test.go
+++ b/api/v1/weightsandbiases_conversion_test.go
@@ -105,23 +105,27 @@ func TestConvertTo_HostnameAndLicense(t *testing.T) {
 }
 
 func TestConvertTo_AllValidSizes(t *testing.T) {
-	cases := []appsv2.Size{
-		appsv2.SizeDev,
-		appsv2.SizeMicro,
-		appsv2.SizeSmall,
-		appsv2.SizeMedium,
-		appsv2.SizeLarge,
-		appsv2.SizeXLarge,
-		appsv2.SizeXXLarge,
+	cases := []struct {
+		input appsv2.Size
+		want  appsv2.Size
+	}{
+		{input: appsv2.SizeDev, want: appsv2.SizeDev},
+		{input: appsv2.SizeMicro, want: appsv2.SizeMicro},
+		{input: appsv2.SizeSmall, want: appsv2.SizeSmall},
+		{input: appsv2.SizeMedium, want: appsv2.SizeMedium},
+		{input: appsv2.SizeLarge, want: appsv2.SizeLarge},
+		{input: appsv2.SizeXLarge, want: appsv2.SizeXLarge},
+		{input: appsv2.Size2XLarge, want: appsv2.Size2XLarge},
+		{input: appsv2.SizeXXLarge, want: appsv2.Size2XLarge},
 	}
-	for _, size := range cases {
-		t.Run(string(size), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(string(tc.input), func(t *testing.T) {
 			dst := &appsv2.WeightsAndBiases{}
 			src := newV1(map[string]interface{}{
-				"global": map[string]interface{}{"size": string(size)},
+				"global": map[string]interface{}{"size": string(tc.input)},
 			})
 			require.NoError(t, src.ConvertTo(dst))
-			require.Equal(t, size, dst.Spec.Size)
+			require.Equal(t, tc.want, dst.Spec.Size)
 		})
 	}
 }

--- a/api/v2/size_test.go
+++ b/api/v2/size_test.go
@@ -1,0 +1,23 @@
+package v2
+
+import "testing"
+
+func TestSizeCanonical(t *testing.T) {
+	tests := []struct {
+		name string
+		size Size
+		want Size
+	}{
+		{name: "canonical 2xlarge", size: Size2XLarge, want: Size2XLarge},
+		{name: "legacy xxlarge", size: SizeXXLarge, want: Size2XLarge},
+		{name: "other size", size: SizeLarge, want: SizeLarge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.size.Canonical(); got != tt.want {
+				t.Fatalf("Canonical() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/v2/weightsandbiases_types.go
+++ b/api/v2/weightsandbiases_types.go
@@ -90,8 +90,18 @@ const (
 	SizeMedium  Size = "medium"
 	SizeLarge   Size = "large"
 	SizeXLarge  Size = "xlarge"
+	Size2XLarge Size = "2xlarge"
+	// SizeXXLarge is the legacy spelling of Size2XLarge.
 	SizeXXLarge Size = "xxlarge"
 )
+
+// Canonical returns the canonical spelling used by server-manifest sizing keys.
+func (s Size) Canonical() Size {
+	if s == SizeXXLarge {
+		return Size2XLarge
+	}
+	return s
+}
 
 type OnDeletePolicy string
 
@@ -110,7 +120,7 @@ type RetentionPolicy struct {
 // WeightsAndBiasesSpec defines the desired state of WeightsAndBiases.
 type WeightsAndBiasesSpec struct {
 	// Size is akin to high-level environment info
-	// +kubebuilder:validation:Enum=dev;micro;small;medium;large;xlarge;xxlarge
+	// +kubebuilder:validation:Enum=dev;micro;small;medium;large;xlarge;"2xlarge";xxlarge
 	Size Size `json:"size,omitempty"`
 	// RequireLimits By default, only resource requests are set for deployments, set to true to also set resource limits
 	RequireLimits bool `json:"requireLimits,omitempty"`

--- a/config/crd/bases/apps.wandb.com_weightsandbiases.yaml
+++ b/config/crd/bases/apps.wandb.com_weightsandbiases.yaml
@@ -3955,6 +3955,7 @@ spec:
                 - medium
                 - large
                 - xlarge
+                - 2xlarge
                 - xxlarge
                 type: string
               tolerations:

--- a/internal/controller/reconciler/reconcile_v2_objectstore_sizing_test.go
+++ b/internal/controller/reconciler/reconcile_v2_objectstore_sizing_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ObjectStore sizing per tier", func() {
 		Entry("medium", apiv2.Size("medium"), int32(3), "100Gi", "001", "4", "20Gi"),
 		Entry("large", apiv2.Size("large"), int32(3), "200Gi", "001", "8", "40Gi"),
 		Entry("xlarge", apiv2.Size("xlarge"), int32(3), "200Gi", "001", "8", "20Gi"),
-		Entry("2xlarge", apiv2.Size("2xlarge"), int32(3), "200Gi", "001", "8", "20Gi"),
+		Entry("2xlarge", apiv2.Size2XLarge, int32(3), "200Gi", "001", "8", "20Gi"),
 	)
 
 	It("lets a CR filer size override the manifest metadataVolumeSize", func() {

--- a/internal/controller/reconciler/reconcile_v2_sizing_test.go
+++ b/internal/controller/reconciler/reconcile_v2_sizing_test.go
@@ -14,6 +14,31 @@ import (
 
 var _ = Describe("ReconcileV2 Sizing", func() {
 	Context("resolveResources", func() {
+		It("uses 2xlarge sizing for the legacy xxlarge spelling", func() {
+			app := serverManifest.Application{
+				Sizing: map[apiv2.Size]serverManifest.SizingConfig{
+					apiv2.Size2XLarge: {
+						Resources: &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("2"),
+							},
+						},
+					},
+				},
+			}
+			wandb := &apiv2.WeightsAndBiases{
+				Spec: apiv2.WeightsAndBiasesSpec{
+					Size:          apiv2.SizeXXLarge,
+					RequireLimits: true,
+				},
+			}
+
+			res := v2.ResolveResources(app, wandb, nil)
+
+			Expect(res).NotTo(BeNil())
+			Expect(res.Requests.Cpu().String()).To(Equal("2"))
+		})
+
 		It("should apply resources from the 'default' key if present", func() {
 			app := serverManifest.Application{
 				Sizing: map[apiv2.Size]serverManifest.SizingConfig{

--- a/internal/controller/reconciler/sizing.go
+++ b/internal/controller/reconciler/sizing.go
@@ -7,6 +7,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+func resolveSizeConfig[T any](sizing map[v2.Size]T, size v2.Size) (T, bool) {
+	config, ok := sizing[size.Canonical()]
+	return config, ok
+}
+
 func ResolveResources(app manifest.Application, wandb *v2.WeightsAndBiases, containerResources *v1.ResourceRequirements) *v1.ResourceRequirements {
 	var resources *v1.ResourceRequirements
 
@@ -16,7 +21,7 @@ func ResolveResources(app manifest.Application, wandb *v2.WeightsAndBiases, cont
 	}
 
 	// check if there is a sizing config in the map that corresponds to the size in the wandb spec and apply that
-	if sizeConfig, ok := app.Sizing[wandb.Spec.Size]; ok && sizeConfig.Resources != nil {
+	if sizeConfig, ok := resolveSizeConfig(app.Sizing, wandb.Spec.Size); ok && sizeConfig.Resources != nil {
 		resources = mergeResources(resources, sizeConfig.Resources, wandb.Spec.RequireLimits)
 	}
 
@@ -52,7 +57,7 @@ func ResolveAutoscaling(app manifest.Application, wandb *v2.WeightsAndBiases) *v
 	}
 
 	// check if there is a sizing config in the map that corresponds to the size in the wandb spec and apply that
-	if sizeConfig, ok := app.Sizing[wandb.Spec.Size]; ok && sizeConfig.Autoscaling != nil {
+	if sizeConfig, ok := resolveSizeConfig(app.Sizing, wandb.Spec.Size); ok && sizeConfig.Autoscaling != nil {
 		if sizeConfig.Autoscaling.Horizontal.MinReplicas != nil {
 			hpa.MinReplicas = sizeConfig.Autoscaling.Horizontal.MinReplicas
 		}
@@ -157,7 +162,7 @@ func ResolveInfraSizing(sizing map[v2.Size]manifest.SizingConfig, size v2.Size, 
 	}
 
 	// Override with size-specific sizing, merging resources
-	if sizeSizing, ok := sizing[size]; ok {
+	if sizeSizing, ok := resolveSizeConfig(sizing, size); ok {
 		if sizeSizing.Replicas != 0 {
 			result.Replicas = sizeSizing.Replicas
 		}
@@ -196,7 +201,7 @@ func ResolveKafkaSizing(sizing map[v2.Size]manifest.KafkaSizingConfig, size v2.S
 		}
 	}
 
-	if sizeSizing, ok := sizing[size]; ok {
+	if sizeSizing, ok := resolveSizeConfig(sizing, size); ok {
 		if sizeSizing.Replicas != 0 {
 			result.Replicas = sizeSizing.Replicas
 		}

--- a/internal/crdinstaller/crds/operator/apps.wandb.com_weightsandbiases.yaml
+++ b/internal/crdinstaller/crds/operator/apps.wandb.com_weightsandbiases.yaml
@@ -3955,6 +3955,7 @@ spec:
                 - medium
                 - large
                 - xlarge
+                - 2xlarge
                 - xxlarge
                 type: string
               tolerations:

--- a/internal/webhook/v2/weightsandbiases_webhook.go
+++ b/internal/webhook/v2/weightsandbiases_webhook.go
@@ -80,6 +80,7 @@ func (d *WeightsAndBiasesCustomDefaulter) Default(ctx context.Context, obj runti
 	if wandb.Spec.Size == "" {
 		wandb.Spec.Size = appsv2.SizeDev
 	}
+	wandb.Spec.Size = wandb.Spec.Size.Canonical()
 
 	if wandb.Spec.RetentionPolicy.OnDelete == "" {
 		wandb.Spec.RetentionPolicy.OnDelete = appsv2.DetachOnDelete

--- a/internal/webhook/v2/weightsandbiases_webhook_test.go
+++ b/internal/webhook/v2/weightsandbiases_webhook_test.go
@@ -119,6 +119,14 @@ var _ = Describe("WeightsAndBiases Webhook", func() {
 			Expect(obj.Status.Wandb.Applications).To(HaveKey("api"))
 		})
 
+		It("normalizes the legacy xxlarge size spelling", func() {
+			obj.Spec.Size = appsv2.SizeXXLarge
+
+			Expect(defaulter.Default(ctx, obj)).To(Succeed())
+
+			Expect(obj.Spec.Size).To(Equal(appsv2.Size2XLarge))
+		})
+
 		It("returns an error for wrong object type", func() {
 			err := defaulter.Default(ctx, &corev1.Pod{})
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
## Summary

- make `2xlarge` the canonical v2 size spelling while retaining `xxlarge` as a compatibility alias
- normalize legacy values during admission, reconciliation, and v1-to-v2 conversion
- update generated and embedded CRDs to accept both spellings

## Testing

- `go test ./api/v1 ./api/v2 ./internal/controller/reconciler ./internal/webhook/v2`
- `go vet ./...`
- `make manifests sync-crd-embed`