### PR TITLE
chore(release): Operator 2.0.0-beta.4

### DIFF
--- a/deploy/operator/Chart.yaml
+++ b/deploy/operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: operator
 description: A Helm chart for Weights & Biases operator
 type: application
-version: 2.0.0-beta.3
-appVersion: "2.0.0-beta.3"
+version: 2.0.0-beta.4
+appVersion: "2.0.0-beta.4"
 maintainers:
   - name: wandb
     email: support@wandb.com

--- a/deploy/operator/values.yaml
+++ b/deploy/operator/values.yaml
@@ -8,7 +8,7 @@ openshift:
 wandb-operator:
   image:
     repository: us-docker.pkg.dev/wandb-production/public/wandb/operator
-    tag: 2.0.0-beta.3
+    tag: 2.0.0-beta.4
   containers:
     operator:
       command:


### PR DESCRIPTION
Updating Chart version to `2.0.0-beta.4` along with the WandB application version