### PR TITLE
feat: add apply pending age metric

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"github.com/wandb/operator/internal/controller"
+	operatormetrics "github.com/wandb/operator/internal/metrics"
 	"github.com/wandb/operator/pkg/wandb/spec/channel/deployer"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -38,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -228,6 +230,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	controllermetrics.Registry.MustRegister(operatormetrics.NewApplyPendingCollector(mgr.GetCache()))
 
 	if err = (&controller.WeightsAndBiasesReconciler{
 		IsAirgapped:               airgapped,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
 	helm.sh/helm/v4 v4.1.4
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -79,6 +80,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
@@ -100,7 +102,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/apply_pending.go
+++ b/internal/controller/apply_pending.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	apiv1 "github.com/wandb/operator/api/v1"
+	operatormetrics "github.com/wandb/operator/internal/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *WeightsAndBiasesReconciler) ensureApplyPendingSince(
+	ctx context.Context,
+	wandb *apiv1.WeightsAndBiases,
+	now time.Time,
+) error {
+	pendingSince, err := time.Parse(time.RFC3339Nano, wandb.Annotations[operatormetrics.ApplyPendingSinceAnnotation])
+	if err == nil && !pendingSince.After(now) {
+		return nil
+	}
+
+	original := wandb.DeepCopy()
+	if wandb.Annotations == nil {
+		wandb.Annotations = map[string]string{}
+	}
+	wandb.Annotations[operatormetrics.ApplyPendingSinceAnnotation] = now.UTC().Format(time.RFC3339Nano)
+	return r.Patch(ctx, wandb, client.MergeFrom(original))
+}
+
+func (r *WeightsAndBiasesReconciler) clearApplyPendingSince(
+	ctx context.Context,
+	wandb *apiv1.WeightsAndBiases,
+) error {
+	if _, exists := wandb.Annotations[operatormetrics.ApplyPendingSinceAnnotation]; !exists {
+		return nil
+	}
+
+	original := wandb.DeepCopy()
+	delete(wandb.Annotations, operatormetrics.ApplyPendingSinceAnnotation)
+	return r.Patch(ctx, wandb, client.MergeFrom(original))
+}

--- a/internal/controller/apply_pending_test.go
+++ b/internal/controller/apply_pending_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/wandb/operator/api/v1"
+	operatormetrics "github.com/wandb/operator/internal/metrics"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyPendingAnnotationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	scheme := runtime.NewScheme()
+	if err := apiv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("could not register WeightsAndBiases types: %v", err)
+	}
+
+	instance := &apiv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "default",
+		Annotations: map[string]string{
+			"example.com/unrelated": "preserved",
+		},
+	}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build()
+	reconciler := &WeightsAndBiasesReconciler{Client: k8sClient}
+
+	if err := reconciler.ensureApplyPendingSince(ctx, instance, now); err != nil {
+		t.Fatalf("ensureApplyPendingSince() error = %v", err)
+	}
+	assertAnnotation(t, ctx, k8sClient, operatormetrics.ApplyPendingSinceAnnotation, now.Format(time.RFC3339Nano))
+
+	if err := reconciler.ensureApplyPendingSince(ctx, instance, now.Add(time.Hour)); err != nil {
+		t.Fatalf("second ensureApplyPendingSince() error = %v", err)
+	}
+	assertAnnotation(t, ctx, k8sClient, operatormetrics.ApplyPendingSinceAnnotation, now.Format(time.RFC3339Nano))
+
+	if err := reconciler.clearApplyPendingSince(ctx, instance); err != nil {
+		t.Fatalf("clearApplyPendingSince() error = %v", err)
+	}
+	assertAnnotation(t, ctx, k8sClient, operatormetrics.ApplyPendingSinceAnnotation, "")
+	assertAnnotation(t, ctx, k8sClient, "example.com/unrelated", "preserved")
+}
+
+func TestEnsureApplyPendingSinceReplacesInvalidTimestamp(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	scheme := runtime.NewScheme()
+	if err := apiv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("could not register WeightsAndBiases types: %v", err)
+	}
+
+	instance := &apiv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "default",
+		Annotations: map[string]string{
+			operatormetrics.ApplyPendingSinceAnnotation: "not-a-time",
+		},
+	}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance).Build()
+	reconciler := &WeightsAndBiasesReconciler{Client: k8sClient}
+
+	if err := reconciler.ensureApplyPendingSince(ctx, instance, now); err != nil {
+		t.Fatalf("ensureApplyPendingSince() error = %v", err)
+	}
+	assertAnnotation(t, ctx, k8sClient, operatormetrics.ApplyPendingSinceAnnotation, now.Format(time.RFC3339Nano))
+}
+
+func assertAnnotation(
+	t *testing.T,
+	ctx context.Context,
+	k8sClient client.Client,
+	key string,
+	want string,
+) {
+	t.Helper()
+	instance := &apiv1.WeightsAndBiases{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "test", Namespace: "default"}, instance); err != nil {
+		t.Fatalf("could not get WeightsAndBiases instance: %v", err)
+	}
+	if got := instance.Annotations[key]; got != want {
+		t.Fatalf("annotation %q = %q, want %q", key, got, want)
+	}
+}

--- a/internal/controller/weightsandbiases_controller.go
+++ b/internal/controller/weightsandbiases_controller.go
@@ -250,6 +250,9 @@ func (r *WeightsAndBiasesReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			log.Info("Active spec found", "spec", currentActiveSpec.SensitiveValuesMasked())
 			if currentActiveSpec.IsEqual(desiredSpec) {
 				log.Info("No changes found")
+				if err := r.clearApplyPendingSince(ctx, wandb); err != nil {
+					log.Error(err, "Failed to clear apply pending annotation")
+				}
 				if err := r.completeManagedSpecCutoverIfNeeded(ctx, wandb.Namespace, shouldCompleteManagedSpecCutover); err != nil {
 					log.Error(err, "Failed to persist managed spec cutover")
 					return ctrlqueue.RequeueWithError(err)
@@ -260,6 +263,10 @@ func (r *WeightsAndBiasesReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				diff := currentActiveSpec.DiffValues(desiredSpec)
 				log.Info("Changes found", "diff", diff)
 			}
+		}
+
+		if err := r.ensureApplyPendingSince(ctx, wandb, time.Now()); err != nil {
+			log.Error(err, "Failed to persist apply pending annotation")
 		}
 
 		if desiredSpec.Chart == nil {
@@ -302,6 +309,9 @@ func (r *WeightsAndBiasesReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		if r.Debug {
 			log.Info("Successfully saved active spec", "spec", desiredSpec.SensitiveValuesMasked())
+		}
+		if err := r.clearApplyPendingSince(ctx, wandb); err != nil {
+			log.Error(err, "Failed to clear apply pending annotation")
 		}
 		if err := r.completeManagedSpecCutoverIfNeeded(ctx, wandb.Namespace, shouldCompleteManagedSpecCutover); err != nil {
 			log.Error(err, "Failed to persist managed spec cutover")

--- a/internal/metrics/apply_pending.go
+++ b/internal/metrics/apply_pending.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apiv1 "github.com/wandb/operator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	ApplyPendingSinceAnnotation = "operator.wandb.com/apply-pending-since"
+	applyPendingAgeMetricName   = "wandb_operator_apply_pending_age_seconds"
+)
+
+type applyPendingCollector struct {
+	reader client.Reader
+	now    func() time.Time
+	desc   *prometheus.Desc
+}
+
+// NewApplyPendingCollector returns a collector that derives pending age from WeightsAndBiases annotations.
+func NewApplyPendingCollector(reader client.Reader) prometheus.Collector {
+	return newApplyPendingCollector(reader, time.Now)
+}
+
+func newApplyPendingCollector(reader client.Reader, now func() time.Time) *applyPendingCollector {
+	return &applyPendingCollector{
+		reader: reader,
+		now:    now,
+		desc: prometheus.NewDesc(
+			applyPendingAgeMetricName,
+			"Seconds since the operator first observed unapplied desired state; 0 when fully applied.",
+			[]string{"namespace", "name"},
+			nil,
+		),
+	}
+}
+
+func (c *applyPendingCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *applyPendingCollector) Collect(ch chan<- prometheus.Metric) {
+	instances := &apiv1.WeightsAndBiasesList{}
+	if err := c.reader.List(context.Background(), instances); err != nil {
+		ctrllog.Log.Error(err, "Failed to list WeightsAndBiases instances for apply pending metric")
+		return
+	}
+
+	now := c.now()
+	for i := range instances.Items {
+		instance := &instances.Items[i]
+		age := applyPendingAge(instance, now)
+		ch <- prometheus.MustNewConstMetric(
+			c.desc,
+			prometheus.GaugeValue,
+			age.Seconds(),
+			instance.Namespace,
+			instance.Name,
+		)
+	}
+}
+
+func applyPendingAge(instance *apiv1.WeightsAndBiases, now time.Time) time.Duration {
+	if !instance.DeletionTimestamp.IsZero() {
+		return 0
+	}
+
+	pendingSince, err := time.Parse(time.RFC3339Nano, instance.Annotations[ApplyPendingSinceAnnotation])
+	if err != nil || pendingSince.After(now) {
+		return 0
+	}
+	return now.Sub(pendingSince)
+}

--- a/internal/metrics/apply_pending_test.go
+++ b/internal/metrics/apply_pending_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	apiv1 "github.com/wandb/operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyPendingCollector(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	scheme := runtime.NewScheme()
+	if err := apiv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("could not register WeightsAndBiases types: %v", err)
+	}
+
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&apiv1.WeightsAndBiases{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "applied",
+				Namespace: "default",
+			},
+		},
+		&apiv1.WeightsAndBiases{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pending",
+				Namespace: "wandb-test",
+				Annotations: map[string]string{
+					ApplyPendingSinceAnnotation: now.Add(-10 * time.Minute).Format(time.RFC3339Nano),
+				},
+			},
+		},
+		&apiv1.WeightsAndBiases{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "invalid-annotation",
+				Namespace: "default",
+				Annotations: map[string]string{
+					ApplyPendingSinceAnnotation: "not-a-time",
+				},
+			},
+		},
+	).Build()
+
+	collector := newApplyPendingCollector(reader, func() time.Time { return now })
+	expected := `
+# HELP wandb_operator_apply_pending_age_seconds Seconds since the operator first observed unapplied desired state; 0 when fully applied.
+# TYPE wandb_operator_apply_pending_age_seconds gauge
+wandb_operator_apply_pending_age_seconds{name="applied",namespace="default"} 0
+wandb_operator_apply_pending_age_seconds{name="invalid-annotation",namespace="default"} 0
+wandb_operator_apply_pending_age_seconds{name="pending",namespace="wandb-test"} 600
+`
+	if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), applyPendingAgeMetricName); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApplyPendingAgeClampsFutureTimestamps(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	instance := &apiv1.WeightsAndBiases{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{
+			ApplyPendingSinceAnnotation: now.Add(time.Minute).Format(time.RFC3339Nano),
+		},
+	}}
+	if age := applyPendingAge(instance, now); age != 0 {
+		t.Fatalf("applyPendingAge() = %s, want 0", age)
+	}
+}


### PR DESCRIPTION
## Summary

- persist the first observed unapplied desired-state time on the `WeightsAndBiases` resource
- expose `wandb_operator_apply_pending_age_seconds` with `namespace` and `name` labels
- clear pending state after the desired spec is saved as active, or when it already matches the active spec

## Why

Operator apply failure events can resolve during retries and are noisy to alert on directly. A pending-age gauge supports an alert only when unapplied changes remain beyond a meaningful threshold.

The timestamp is stored in `operator.wandb.com/apply-pending-since`, so it survives operator restarts. The collector computes age at scrape time, so the gauge continues to advance between reconciles.

## Impact

No Helm chart or CRD changes are required. The metric uses the existing controller-runtime metrics endpoint and the `wandb_operator_` prefix already collected by Dedicated.

## Validation

- `go vet ./...`
- full non-e2e Go test suite
- focused annotation lifecycle and Prometheus collector tests